### PR TITLE
Prevent non-fatal errors from closing the supervisor.

### DIFF
--- a/gosuper/systemd/systemd.go
+++ b/gosuper/systemd/systemd.go
@@ -17,9 +17,9 @@ var (
 func init() {
 	var err error
 	if Logind, err = login1.New(); err != nil {
-		log.Fatalf("Failed to connect to host system bus: %s", err)
+		log.Printf("Failed to connect to host system bus: %s", err)
 	}
 	if Dbus, err = dbus.New(); err != nil {
-		log.Fatalf("Failed to connect to host DBUS: %s", err)
+		log.Printf("Failed to connect to host DBUS: %s", err)
 	}
 }


### PR DESCRIPTION
connects to #59 

This patch fixes a couple of cases where `log.Fatalf` would cause the supervisor
to exit immediately when it's inappropriate to do so. `log.Fatalf` and
co. should not be used unless the supervisor utterly cannot run without
whatever's being checked being in place.

This patch also adjusts the code that relied on the module's values being
created here being available, they now check and send an appropriate error
message if they're not there.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-io/resin-supervisor/4)

<!-- Reviewable:end -->
