### PR TITLE
Disable docker layer caching on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ defaults: &defaults
   steps:
     - setup_remote_docker:
         version: 18.09.3
-        docker_layer_caching: true
+        docker_layer_caching: false
     - run:
         name: Check docker is running and install git
         command: |


### PR DESCRIPTION
Docker layer caching is a paid plan feature on Circle CI, it has started
being enforced by Circle. Disabling it solves this temporarily while we sort out
a better long term solution for supervisor CI

Change-type: patch
