### PR TITLE
balena-supervisor: replace references to resin-vars

### DIFF
--- a/tools/dind/start-resin-supervisor
+++ b/tools/dind/start-resin-supervisor
@@ -2,8 +2,14 @@
 
 # Adapted from: https://github.com/balena-os/meta-balena/blob/v2.45.0/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
 
+# We still need to include resin-vars on legacy systems
+if [ -f /usr/sbin/resin-vars ]; then
 # shellcheck disable=SC1091
-. /usr/sbin/resin-vars
+  . /usr/sbin/resin-vars
+else
+# shellcheck disable=SC1091
+  . /usr/sbin/balena-config-vars
+fi
 
 if ! balena inspect $SUPERVISOR_IMAGE:$SUPERVISOR_TAG > /dev/null; then
     balena load --input /usr/src/supervisor-image.tar


### PR DESCRIPTION
Replace all references to the 'resin-vars' script with 'balena-config-vars' as it has been renamed.

This PR needs to be merged when https://github.com/balena-os/meta-balena/pull/2142 has been merged.

Change-type: patch
Changelog-entry: balena-supervisor: replace references to resin-vars
Signed-off-by: Mark Corbin <mark@balena.io>