### PR TITLE
Patch list volumes to always return an array

### DIFF
--- a/src/compose/volume-manager.ts
+++ b/src/compose/volume-manager.ts
@@ -154,6 +154,6 @@ export async function removeOrphanedVolumes(
 }
 
 async function list(): Promise<VolumeInspectInfo[]> {
-	const allVolumes = await docker.listVolumes();
-	return _.get(allVolumes, 'Volumes', []);
+	const dockerResponse = await docker.listVolumes();
+	return Array.isArray(dockerResponse.Volumes) ? dockerResponse.Volumes : [];
 }

--- a/test/44-volume-manager.spec.ts
+++ b/test/44-volume-manager.spec.ts
@@ -5,6 +5,7 @@ import * as mockedDockerode from './lib/mocked-dockerode';
 import * as volumeManager from '../src/compose/volume-manager';
 import log from '../src/lib/supervisor-console';
 import Volume from '../src/compose/volume';
+import { VolumeInspectInfo } from 'dockerode';
 
 describe('Volume Manager', () => {
 	let logDebug: SinonStub;
@@ -71,6 +72,16 @@ describe('Volume Manager', () => {
 			]);
 			// Check that debug message was logged saying we found a Volume not created by us
 			expect(logDebug.lastCall.lastArg).to.equal('Cannot parse Volume: decoy');
+		});
+	});
+
+	it('can parse null Volumes', async () => {
+		// Setup volume data
+		// @ts-ignore
+		const volumeData: VolumeInspectInfo[] = null;
+		// Perform test
+		await mockedDockerode.testWithData({ volumes: volumeData }, async () => {
+			await expect(volumeManager.getAll()).to.eventually.deep.equal([]);
 		});
 	});
 


### PR DESCRIPTION
I don't know why or when docker will return null when listing volumes but given the issue's log, when I write a test which passes null response to the volume manager list function, it throws the exact same error. There aren't many places in the codebase which use reduce so it was easy to find the code where `Cannot read property 'reduce' of null` could come from.

Additionally, when I ran my test with the original code before https://github.com/balena-os/balena-supervisor/commit/183ea88a2ad3bbdf18ab96505920465f1a404df0 it does handle null and returns an empty array! 

So, I'm confident this fixes the regression.

Change-type: patch
Closes: #1636
Signed-off-by: Miguel Casqueira <miguel@balena.io>