### PR TITLE
Update setup section to reflect switch to balena-os org

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To get the codebase setup on your development machine follow these steps. For ru
 
 ```sh
 # Clone the repo
-git clone git@github.com:balena-io/balena-supervisor.git
+git clone git@github.com:balena-os/balena-supervisor.git
 
 # Install dependencies
 npm ci


### PR DESCRIPTION
After switch from balena-io org to balena-os, update README instructions to make sure the right git repo is cloned.

Change-type: patch
Signed-off-by: Christina Wang <christina@balena.io>