### PR TITLE
Add log message when deltas become unavailable with Docker daemon 404 while applying

### DIFF
--- a/src/compose/images.ts
+++ b/src/compose/images.ts
@@ -14,7 +14,11 @@ import {
 	dockerToolbelt,
 } from '../lib/docker-utils';
 import * as dockerUtils from '../lib/docker-utils';
-import { DeltaStillProcessingError, NotFoundError } from '../lib/errors';
+import {
+	ImageNotFoundError,
+	DeltaStillProcessingError,
+	NotFoundError,
+} from '../lib/errors';
 import * as LogTypes from '../lib/log-types';
 import * as validation from '../lib/validation';
 import * as logger from '../logger';
@@ -152,7 +156,12 @@ export async function triggerFetch(
 		onFinish(true);
 		return;
 	} catch (e) {
-		if (!NotFoundError(e)) {
+		if (ImageNotFoundError(e)) {
+			// Handle Docker daemon HTTP 404 errors (image not accessible for some reason while needed)
+			log.debug(
+				`Delta image has been modified or deleted by daemon while applying, redownloading: ${image.name}`,
+			);
+		} else if (!NotFoundError(e)) {
 			if (!(e instanceof ImageDownloadBackoffError)) {
 				addImageFailure(image.name);
 			}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -10,6 +10,10 @@ export interface StatusCodeError extends Error {
 	statusCode?: string | number;
 }
 
+export interface DockerDaemonError extends StatusCodeError {
+	reason: string;
+}
+
 interface CodedSysError extends Error {
 	code?: string;
 }
@@ -39,6 +43,12 @@ export function UnitNotLoadedError(err: string[]): boolean {
 export class InvalidNetGatewayError extends TypedError {}
 
 export class DeltaStillProcessingError extends TypedError {}
+
+// This error occurs when the image is removed from balenaEngine while it is needed by the application.
+// It's a 404 error that gets thrown by the Docker daemon.
+export function ImageNotFoundError(err: DockerDaemonError): boolean {
+	return checkInt(err.statusCode) === 404 && err.reason === 'no such image';
+}
 
 export class InvalidAppIdError extends TypedError {
 	public constructor(public appId: any) {


### PR DESCRIPTION
This PR adds the human-friendly warning `Delta image has been modified or deleted by daemon while applying, redownloading` which logs when a 404 is thrown by Docker daemon as a result of an image resource no longer being present when it's needed. Supervisor already handles the redownloading of a delta image when a 404 happens, but before, there was an ugly and alarming `Uncaught exception` error block in the logs. 

I'd hesitate to close the referenced issue with this patch, since that issue also mentions cloud API errors. This patch is one step closer towards better error source communication, but doesn't reach all the way there.

Connects-to: #1295
Change-type: patch
Signed-off-by: Christina Wang <christina@balena.io>