### PR TITLE
patch: Fix substring end parameter to get accurate CPU ID

### DIFF
--- a/src/lib/system-info.ts
+++ b/src/lib/system-info.ts
@@ -69,7 +69,7 @@ export async function getCpuId(): Promise<string | undefined> {
 	try {
 		const buffer = await fs.readFile('/proc/device-tree/serial-number');
 		// Remove the null byte at the end
-		return buffer.toString('utf-8').substr(0, buffer.length - 2);
+		return buffer.toString('utf-8').replace(/\0/g, '');
 	} catch {
 		return undefined;
 	}

--- a/test/38-sys-info.spec.ts
+++ b/test/38-sys-info.spec.ts
@@ -119,7 +119,7 @@ describe('System information', async () => {
 				]),
 			);
 			const cpuId = await sysInfo.getCpuId();
-			expect(cpuId).to.equal('1000000001b93f3');
+			expect(cpuId).to.equal('1000000001b93f3f');
 			fsStub.restore();
 		});
 	});


### PR DESCRIPTION
The `end` parameter of the substring inside the `getCpuId()` function was trimming the last character of the CPU ID. This data was showing up in the API as inaccurate (presumably because maybe the Supervisor API is the one providing the data). 

![Screenshot from 2021-04-06 15-25-37](https://user-images.githubusercontent.com/22801822/114196179-c37af680-996e-11eb-9828-766a90a9dc27.png)


From the screenshot below, one can observe the presence of a null byte after the CPU ID, when running the command `cat -A /proc/device-tree/serial-number`. I tried to `trim()` the null byte but it was no good. So was looking for better solutions than using `substring` to trim the last character. The only other solution described was the use of regex where the case was for multiple null bytes present in the string. 

![Screenshot from 2021-04-09 19-51-53](https://user-images.githubusercontent.com/22801822/114194835-82361700-996d-11eb-9b7c-0b0ad591cf4d.png)

Would like a solution better than substring though, recommendations welcome. 

cc: @Page- 
Closes: https://github.com/balena-io/open-balena-api/issues/631 (I was going to transfer but someone moved the repository to balenaOS 🙃)
Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>