### PR TITLE
Fix broken IPAM network validation

### DIFF
--- a/src/compose/network.ts
+++ b/src/compose/network.ts
@@ -214,8 +214,8 @@ export class Network {
 		},
 	): void {
 		// Check if every ipam config entry has both a subnet and a gateway
-		_.each(_.get(config, 'config.ipam.config', []), ({ subnet, gateway }) => {
-			if (subnet == null || gateway == null) {
+		_.each(_.get(config, 'ipam.config', []), ({ subnet, gateway }) => {
+			if (!subnet || !gateway) {
 				throw new InvalidNetworkConfigurationError(
 					'Network IPAM config entries must have both a subnet and gateway',
 				);

--- a/test/compose/network.spec.ts
+++ b/test/compose/network.spec.ts
@@ -1,0 +1,112 @@
+import ChaiConfig = require('../lib/chai-config');
+const { expect } = ChaiConfig;
+
+import { Network } from '../../src/compose/network';
+
+describe('Network', () => {
+	describe('fromComposeObject', () => {
+		it('creates a default network configuration if no config is given', () => {
+			const network = Network.fromComposeObject('default', 12345, {});
+
+			expect(network.name).to.equal('default');
+			expect(network.appId).to.equal(12345);
+
+			// Default configuration options
+			expect(network.config.driver).to.equal('bridge');
+			expect(network.config.ipam).to.deep.equal({
+				driver: 'default',
+				config: [],
+				options: {},
+			});
+			expect(network.config.enableIPv6).to.equal(false);
+			expect(network.config.labels).to.deep.equal({});
+			expect(network.config.options).to.deep.equal({});
+		});
+
+		it('normalizes legacy labels', () => {
+			const network = Network.fromComposeObject('default', 12345, {
+				labels: {
+					'io.resin.features.something': '1234',
+				},
+			});
+
+			expect(network.config.labels).to.deep.equal({
+				'io.balena.features.something': '1234',
+			});
+		});
+
+		it('accepts valid IPAM configurations', () => {
+			const network0 = Network.fromComposeObject('default', 12345, {
+				ipam: { driver: 'dummy', config: [], options: {} },
+			});
+
+			// Default configuration options
+			expect(network0.config.ipam).to.deep.equal({
+				driver: 'dummy',
+				config: [],
+				options: {},
+			});
+
+			const network1 = Network.fromComposeObject('default', 12345, {
+				ipam: {
+					driver: 'default',
+					config: [
+						{
+							subnet: '172.20.0.0/16',
+							ip_range: '172.20.10.0/24',
+							gateway: '172.20.0.1',
+						},
+					],
+					options: {},
+				},
+			});
+
+			// Default configuration options
+			expect(network1.config.ipam).to.deep.equal({
+				driver: 'default',
+				config: [
+					{
+						subnet: '172.20.0.0/16',
+						ip_range: '172.20.10.0/24',
+						gateway: '172.20.0.1',
+					},
+				],
+				options: {},
+			});
+		});
+
+		it('rejects IPAM configuration without both gateway and subnet', () => {
+			expect(() =>
+				Network.fromComposeObject('default', 12345, {
+					ipam: {
+						driver: 'default',
+						config: [
+							{
+								subnet: '172.20.0.0/16',
+							},
+						],
+						options: {},
+					},
+				}),
+			).to.throw(
+				'Network IPAM config entries must have both a subnet and gateway',
+			);
+
+			expect(() =>
+				Network.fromComposeObject('default', 12345, {
+					ipam: {
+						driver: 'default',
+						config: [
+							{
+								gateway: '172.20.0.1',
+							},
+						],
+						options: {},
+					},
+				}),
+			).to.throw(
+				'Network IPAM config entries must have both a subnet and gateway',
+			);
+		});
+	});
+});

--- a/test/fast-mocha.opts
+++ b/test/fast-mocha.opts
@@ -2,4 +2,4 @@
 --require ts-node/register/transpile-only
 --timeout 30000
 --bail
-test/*.{ts,js}
+test/**/*.spec.ts

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
 --exit
 --timeout 30000
-build/test/*.js
+build/test/**/*.js


### PR DESCRIPTION
Network validaton was failing to identify a bad IPAM network
configuration leading to supervisor failures (see #1618).

This PR also modifies the mocha configuration to perform recursive lookup of `*.spec.ts` files

Change-type: patch
Closes: #1618