### PR TITLE
Refactor extra_uEnv to not match with intel nuc

### DIFF
--- a/src/config/backends/extra-uEnv.ts
+++ b/src/config/backends/extra-uEnv.ts
@@ -60,8 +60,7 @@ export class ExtraUEnv extends ConfigBackend {
 
 	public async matches(deviceType: string): Promise<boolean> {
 		return (
-			(deviceType === 'intel-nuc' ||
-				deviceType.endsWith('-nano') ||
+			(deviceType.endsWith('-nano') ||
 				deviceType.endsWith('-nano-emmc') ||
 				deviceType.endsWith('-tx2')) &&
 			(await fs.exists(ExtraUEnv.bootConfigPath))

--- a/test/33-extra-uenv-config.spec.ts
+++ b/test/33-extra-uenv-config.spec.ts
@@ -261,7 +261,7 @@ const MATCH_TESTS = [
 	{ type: 'jetson-nano-emmc', supported: true },
 	{ type: 'jn30b-nano', supported: true },
 	{ type: 'photon-nano', supported: true },
-	{ type: 'intel-nuc', supported: true },
+	{ type: 'intel-nuc', supported: false },
 	{ type: 'raspberry', supported: false },
 	{ type: 'fincm3', supported: false },
 	{ type: 'asus-tinker-board', supported: false },


### PR DESCRIPTION
From comment https://github.com/balena-os/balena-supervisor/pull/1648#discussion_r606252023 on another PR where I documented that the intel nuc will match with extra_uEnv @acostach said this is not true (reason in that comment). This PR makes the intel nuc not match with this backend.