### PR TITLE
Change 'require' to 'import * from' for dependencies

### DIFF
--- a/src/compose/app.ts
+++ b/src/compose/app.ts
@@ -16,7 +16,7 @@ import {
 } from './composition-steps';
 import * as targetStateCache from '../device-state/target-state-cache';
 import * as dockerUtils from '../lib/docker-utils';
-import constants = require('../lib/constants');
+import * as constants from '../lib/constants';
 
 import { getStepsFromStrategy } from './update-strategies';
 

--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -6,7 +6,7 @@ import * as config from '../config';
 import { transaction, Transaction } from '../db';
 import * as dbFormat from '../device-state/db-format';
 import { validateTargetContracts } from '../lib/contracts';
-import constants = require('../lib/constants');
+import * as constants from '../lib/constants';
 import { docker } from '../lib/docker-utils';
 import * as logger from '../logger';
 import log from '../lib/supervisor-console';

--- a/src/compose/network-manager.ts
+++ b/src/compose/network-manager.ts
@@ -5,7 +5,7 @@ import { fs } from 'mz';
 import * as constants from '../lib/constants';
 import { docker } from '../lib/docker-utils';
 import { ENOENT, NotFoundError } from '../lib/errors';
-import logTypes = require('../lib/log-types');
+import * as logTypes from '../lib/log-types';
 import * as logger from '../logger';
 import { Network } from './network';
 

--- a/src/compose/network.ts
+++ b/src/compose/network.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 
 import { docker } from '../lib/docker-utils';
 import { InvalidAppIdError } from '../lib/errors';
-import logTypes = require('../lib/log-types');
+import * as logTypes from '../lib/log-types';
 import { checkInt } from '../lib/validation';
 import * as logger from '../logger';
 import * as ComposeUtils from './utils';

--- a/src/compose/service-manager.ts
+++ b/src/compose/service-manager.ts
@@ -12,7 +12,7 @@ import { docker } from '../lib/docker-utils';
 import * as logger from '../logger';
 
 import { PermissiveNumber } from '../config/types';
-import constants = require('../lib/constants');
+import * as constants from '../lib/constants';
 import {
 	InternalInconsistencyError,
 	NotFoundError,

--- a/src/compose/volume-manager.ts
+++ b/src/compose/volume-manager.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import * as Path from 'path';
 import { VolumeInspectInfo } from 'dockerode';
 
-import constants = require('../lib/constants');
+import * as constants from '../lib/constants';
 import { NotFoundError, InternalInconsistencyError } from '../lib/errors';
 import { safeRename } from '../lib/fs-utils';
 import { docker } from '../lib/docker-utils';

--- a/src/compose/volume.ts
+++ b/src/compose/volume.ts
@@ -1,9 +1,6 @@
 import * as Docker from 'dockerode';
-import assign = require('lodash/assign');
-import isEqual = require('lodash/isEqual');
-import omitBy = require('lodash/omitBy');
-
-import constants = require('../lib/constants');
+import { assign, isEqual, omitBy } from 'lodash';
+import * as constants from '../lib/constants';
 import { docker } from '../lib/docker-utils';
 import { InternalInconsistencyError } from '../lib/errors';
 import * as LogTypes from '../lib/log-types';

--- a/src/config/functions.ts
+++ b/src/config/functions.ts
@@ -4,7 +4,7 @@ import * as memoizee from 'memoizee';
 import { fs } from 'mz';
 import { URL } from 'url';
 
-import supervisorVersion = require('../lib/supervisor-version');
+import supervisorVersion from '../lib/supervisor-version';
 
 import * as config from '.';
 import * as constants from '../lib/constants';

--- a/src/device-api/v2.ts
+++ b/src/device-api/v2.ts
@@ -27,7 +27,7 @@ import {
 	v2ServiceEndpointInputErrorMessage,
 } from '../lib/messages';
 import log from '../lib/supervisor-console';
-import supervisorVersion = require('../lib/supervisor-version');
+import supervisorVersion from '../lib/supervisor-version';
 import { checkInt, checkTruthy } from '../lib/validation';
 import { isVPNActive } from '../network';
 import { doPurge, doRestart, safeStateClone } from './common';

--- a/src/device-state.ts
+++ b/src/device-state.ts
@@ -19,7 +19,7 @@ import {
 import { loadTargetFromFile } from './device-state/preload';
 import * as globalEventBus from './event-bus';
 import * as hostConfig from './host-config';
-import constants = require('./lib/constants');
+import * as constants from './lib/constants';
 import * as dbus from './lib/dbus';
 import { InternalInconsistencyError, UpdatesLockedError } from './lib/errors';
 import * as updateLock from './lib/update-lock';

--- a/src/device-state/current-state.ts
+++ b/src/device-state/current-state.ts
@@ -1,5 +1,5 @@
-import Bluebird = require('bluebird');
-import constants = require('../lib/constants');
+import * as Bluebird from 'bluebird';
+import * as constants from '../lib/constants';
 import log from '../lib/supervisor-console';
 import * as _ from 'lodash';
 import { InternalInconsistencyError } from '../lib/errors';

--- a/src/device-state/preload.ts
+++ b/src/device-state/preload.ts
@@ -8,7 +8,7 @@ import * as deviceConfig from '../device-config';
 import * as eventTracker from '../event-tracker';
 import * as images from '../compose/images';
 
-import constants = require('../lib/constants');
+import * as constants from '../lib/constants';
 import { AppsJsonParseError, EISDIR, ENOENT } from '../lib/errors';
 import log from '../lib/supervisor-console';
 

--- a/src/device-state/target-state.ts
+++ b/src/device-state/target-state.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import * as url from 'url';
 import { delay } from 'bluebird';
 import * as _ from 'lodash';
-import Bluebird = require('bluebird');
+import * as Bluebird from 'bluebird';
 import type StrictEventEmitter from 'strict-event-emitter-types';
 
 import type { TargetState } from '../types/state';
@@ -11,7 +11,7 @@ import { getRequestInstance } from '../lib/request';
 import { CoreOptions } from 'request';
 import * as config from '../config';
 import { writeLock } from '../lib/update-lock';
-import constants = require('../lib/constants');
+import * as constants from '../lib/constants';
 import log from '../lib/supervisor-console';
 
 export class ApiResponseError extends Error {}

--- a/src/event-tracker.ts
+++ b/src/event-tracker.ts
@@ -5,7 +5,7 @@ import * as mixpanel from 'mixpanel';
 
 import * as config from './config';
 import log from './lib/supervisor-console';
-import supervisorVersion = require('./lib/supervisor-version');
+import supervisorVersion from './lib/supervisor-version';
 
 export type EventTrackProperties = Dictionary<any>;
 

--- a/src/lib/blink.ts
+++ b/src/lib/blink.ts
@@ -1,5 +1,6 @@
-import blinking = require('blinking');
+import blinking = require('blinking'); // blinking is a 'coffee' module and can only be imported this way
+import * as constants from './constants';
 
-import constants = require('./constants');
+const blink = blinking(constants.ledFile);
 
-export = blinking(constants.ledFile);
+export default blink;

--- a/src/lib/journald.ts
+++ b/src/lib/journald.ts
@@ -1,6 +1,6 @@
 import { ChildProcess, spawn } from 'child_process';
 
-import constants = require('./constants');
+import * as constants from './constants';
 import log from './supervisor-console';
 
 export function spawnJournalctl(opts: {

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -1,12 +1,12 @@
 import * as Bluebird from 'bluebird';
-import once = require('lodash/once');
+import * as _ from 'lodash';
 import * as requestLib from 'request';
 import * as resumableRequestLib from 'resumable-request';
 
 import * as constants from './constants';
 import * as osRelease from './os-release';
 
-import supervisorVersion = require('./supervisor-version');
+import supervisorVersion from './supervisor-version';
 
 export { requestLib };
 
@@ -40,7 +40,7 @@ type PromisifiedRequest = typeof requestLib & {
 	) => Bluebird<[requestLib.Response, any]>;
 };
 
-const getRequestInstances = once(async () => {
+const getRequestInstances = _.once(async () => {
 	// Generate the user agents with out versions
 	const osVersion = await osRelease.getOSVersion(constants.hostOSVersionPath);
 	const osVariant = await osRelease.getOSVariant(constants.hostOSVersionPath);
@@ -81,14 +81,14 @@ const getRequestInstances = once(async () => {
 	};
 });
 
-export const getRequestInstance = once(async () => {
+export const getRequestInstance = _.once(async () => {
 	return (await getRequestInstances()).request;
 });
 
-export const getRequestOptions = once(async () => {
+export const getRequestOptions = _.once(async () => {
 	return (await getRequestInstances()).requestOpts;
 });
 
-export const getResumableRequest = once(async () => {
+export const getResumableRequest = _.once(async () => {
 	return (await getRequestInstances()).resumable;
 });

--- a/src/lib/supervisor-version.ts
+++ b/src/lib/supervisor-version.ts
@@ -7,4 +7,4 @@ const tagExtra = process.env.SUPERVISOR_TAG_EXTRA;
 if (!_.isEmpty(tagExtra)) {
 	version += '+' + tagExtra;
 }
-export = version;
+export default version;

--- a/src/lib/update-lock.ts
+++ b/src/lib/update-lock.ts
@@ -5,7 +5,7 @@ import { fs } from 'mz';
 import * as path from 'path';
 import * as Lock from 'rwlock';
 
-import constants = require('./constants');
+import * as constants from './constants';
 import { ENOENT, UpdatesLockedError } from './errors';
 
 type asyncLockFile = typeof lockFileLib & {

--- a/src/network.ts
+++ b/src/network.ts
@@ -9,7 +9,7 @@ import * as constants from './lib/constants';
 import { EEXIST } from './lib/errors';
 import { checkFalsey } from './lib/validation';
 
-import blink = require('./lib/blink');
+import blink from './lib/blink';
 
 import log from './lib/supervisor-console';
 

--- a/src/supervisor-api.ts
+++ b/src/supervisor-api.ts
@@ -5,7 +5,7 @@ import * as _ from 'lodash';
 import * as morgan from 'morgan';
 
 import * as eventTracker from './event-tracker';
-import blink = require('./lib/blink');
+import blink from './lib/blink';
 
 import log from './lib/supervisor-console';
 import * as apiKeys from './lib/api-keys';

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -10,7 +10,7 @@ import * as logger from './logger';
 import SupervisorAPI from './supervisor-api';
 
 import log from './lib/supervisor-console';
-import version = require('./lib/supervisor-version');
+import version from './lib/supervisor-version';
 
 import * as avahi from './lib/avahi';
 import * as firewall from './lib/firewall';

--- a/test/07-blink.spec.ts
+++ b/test/07-blink.spec.ts
@@ -1,7 +1,7 @@
 import { fs } from 'mz';
 import { expect } from './lib/chai-config';
 
-import blink = require('../src/lib/blink');
+import blink from '../src/lib/blink';
 import constants = require('../src/lib/constants');
 
 describe('blink', () => {

--- a/test/08-event-tracker.spec.ts
+++ b/test/08-event-tracker.spec.ts
@@ -4,7 +4,7 @@ import { SinonStub, stub, spy, SinonSpy } from 'sinon';
 import { expect } from './lib/chai-config';
 
 import log from '../src/lib/supervisor-console';
-import supervisorVersion = require('../src/lib/supervisor-version');
+import supervisorVersion from '../src/lib/supervisor-version';
 import * as config from '../src/config';
 
 describe('EventTracker', () => {

--- a/test/23-contracts.spec.ts
+++ b/test/23-contracts.spec.ts
@@ -11,7 +11,7 @@ import {
 	validateContract,
 } from '../src/lib/contracts';
 import * as osRelease from '../src/lib/os-release';
-import supervisorVersion = require('../src/lib/supervisor-version');
+import supervisorVersion from '../src/lib/supervisor-version';
 
 describe('Container contracts', () => {
 	before(() => {

--- a/test/41-device-api-v1.spec.ts
+++ b/test/41-device-api-v1.spec.ts
@@ -27,7 +27,7 @@ import * as dbus from '../src//lib/dbus';
 import * as updateLock from '../src/lib/update-lock';
 import * as TargetState from '../src/device-state/target-state';
 import * as targetStateCache from '../src/device-state/target-state-cache';
-import blink = require('../src/lib/blink');
+import blink from '../src/lib/blink';
 import constants = require('../src/lib/constants');
 import * as deviceAPI from '../src/device-api/common';
 


### PR DESCRIPTION
This refactors imports for all typescript compatible modules from
`require`, to `import * from`. This change has no effect in code
execution, it's only about code consistency.

This has the added benefit of allowing us to identify all non-typescript
external modules and look for possible alternatives.

Change-type: patch