### PR TITLE
Support app uuids and release version on target state

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -28,6 +28,14 @@ if [ -z "$DOCKER_SOCKET" ]; then
 	export DOCKER_SOCKET=/run/docker.sock
 fi
 
+# Use a trick to get the container id from inside the container itself in
+# in case the supervisor is started some other way than with the start-resin-supervisor
+# script. This will not work with cgrous v2
+# https://stackoverflow.com/a/25729598
+if [ -z "${SUPERVISOR_CONTAINER_ID}" ]; then
+	SUPERVISOR_CONTAINER_ID=$(cat /proc/self/cgroup | grep -o  -e "docker-.*.scope" | head -n 1 | sed "s/docker-\(.*\).scope/\\1/")
+fi
+
 export DBUS_SYSTEM_BUS_ADDRESS="unix:path=/mnt/root/run/dbus/system_bus_socket"
 
 # Include self-signed CAs, should they exist

--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -40,6 +40,8 @@ import { checkTruthy, checkInt } from '../lib/validation';
 import { Proxyvisor } from '../proxyvisor';
 import * as updateLock from '../lib/update-lock';
 import { EventEmitter } from 'events';
+import Network from './network';
+import Volume from './volume';
 
 type ApplicationManagerEventEmitter = StrictEventEmitter<
 	EventEmitter,
@@ -233,6 +235,7 @@ export async function getRequiredSteps(
 
 		// We want to remove images before moving on to anything else
 		if (steps.length === 0) {
+			// TODO: this should be comparing by uuid if available
 			const targetAndCurrent = _.intersection(currentAppIds, targetAppIds);
 			const onlyTarget = _.difference(targetAppIds, currentAppIds);
 			const onlyCurrent = _.difference(currentAppIds, targetAppIds);
@@ -241,7 +244,7 @@ export async function getRequiredSteps(
 			// do to move to the target state
 			for (const id of targetAndCurrent) {
 				steps = steps.concat(
-					await currentApps[id].nextStepsForAppUpdate(
+					currentApps[id].nextStepsForAppUpdate(
 						{
 							localMode,
 							availableImages,
@@ -267,10 +270,11 @@ export async function getRequiredSteps(
 			// For apps in the target state but not the current state, we generate steps to
 			// create the app by mocking an existing app which contains nothing
 			for (const id of onlyTarget) {
-				const { appId } = targetApps[id];
+				const { appId, uuid } = targetApps[id];
 				const emptyCurrent = new App(
 					{
 						appId,
+						uuid,
 						services: [],
 						volumes: {},
 						networks: {},
@@ -367,33 +371,146 @@ export async function getCurrentAppsForReport(): Promise<
 	return appsToReport;
 }
 
+// The following two function may look pretty odd, but after the move to uuids,
+// there's a chance that the current running apps don't have a uuid set. We
+// still need to be able to work on these and perform various state changes. To
+// do this we try to use the UUID to group the components, and if that isn't
+// available we revert to using the appIds instead
 export async function getCurrentApps(): Promise<InstancedAppState> {
-	const volumes = _.groupBy(await volumeManager.getAll(), 'appId');
-	const networks = _.groupBy(await networkManager.getAll(), 'appId');
-	const services = _.groupBy(await serviceManager.getAll(), 'appId');
-
-	const allAppIds = _.union(
-		Object.keys(volumes),
-		Object.keys(networks),
-		Object.keys(services),
-	).map((i) => parseInt(i, 10));
+	const componentGroups = groupComponents(
+		await serviceManager.getAll(),
+		await networkManager.getAll(),
+		await volumeManager.getAll(),
+	);
 
 	const apps: InstancedAppState = {};
-	for (const appId of allAppIds) {
+	for (const strAppId of Object.keys(componentGroups)) {
+		const appId = parseInt(strAppId, 10);
+
+		// TODO: get commit and release version from container
 		const commit = await commitStore.getCommitForApp(appId);
-		apps[appId] = new App(
-			{
-				appId,
-				services: services[appId] ?? [],
-				networks: _.keyBy(networks[appId], 'name'),
-				volumes: _.keyBy(volumes[appId], 'name'),
-				commit,
-			},
-			false,
-		);
+
+		const components = componentGroups[appId];
+
+		// fetch the correct uuid from any component within the appId
+		const uuid = [
+			components.services[0]?.uuid,
+			components.volumes[0]?.uuid,
+			components.networks[0]?.uuid,
+		]
+			.filter((u) => u != null)
+			.shift()!;
+
+		// If we don't have any components for this app, ignore it (this can
+		// actually happen when moving between backends but maintaining UUIDs)
+		if (
+			!_.isEmpty(components.services) ||
+			!_.isEmpty(components.volumes) ||
+			!_.isEmpty(components.networks)
+		) {
+			apps[appId] = new App(
+				{
+					appId,
+					uuid,
+					commit,
+					services: componentGroups[appId].services,
+					networks: _.keyBy(componentGroups[appId].networks, 'name'),
+					volumes: _.keyBy(componentGroups[appId].volumes, 'name'),
+				},
+				false,
+			);
+		}
 	}
 
 	return apps;
+}
+
+interface AppGroup {
+	[appId: number]: {
+		services: Service[];
+		volumes: Volume[];
+		networks: Network[];
+	};
+}
+
+function groupComponents(
+	services: Service[],
+	networks: Network[],
+	volumes: Volume[],
+): AppGroup {
+	const grouping: AppGroup = {};
+
+	const everyComponent: [{ uuid?: string; appId: number }] = [
+		...services,
+		...networks,
+		...volumes,
+	] as any;
+
+	const allUuids: string[] = [];
+	const allAppIds: number[] = [];
+	everyComponent.forEach(({ appId, uuid }) => {
+		// Pre-populate the groupings
+		grouping[appId] = {
+			services: [],
+			networks: [],
+			volumes: [],
+		};
+		// Save all the uuids for later
+		if (uuid != null) {
+			allUuids.push(uuid);
+		}
+		allAppIds.push(appId);
+	});
+
+	// First we try to group everything by it's uuid, but if any component does
+	// not have a uuid, we fall back to the old appId style
+	if (everyComponent.length === allUuids.length) {
+		const uuidGroups: { [uuid: string]: AppGroup[0] } = {};
+		_.uniq(allUuids).forEach((uuid) => {
+			const uuidServices = services.filter(({ uuid: sUuid }) => uuid === sUuid);
+			const uuidVolumes = volumes.filter(({ uuid: vUuid }) => uuid === vUuid);
+			const uuidNetworks = networks.filter(({ uuid: nUuid }) => uuid === nUuid);
+
+			uuidGroups[uuid] = {
+				services: uuidServices,
+				networks: uuidNetworks,
+				volumes: uuidVolumes,
+			};
+		});
+
+		for (const uuid of Object.keys(uuidGroups)) {
+			// There's a chance that the uuid and the appId is different, and this
+			// is fine. Unfortunately we have no way of knowing which is the "real"
+			// appId (that is the app id which relates to the currently joined
+			// backend) so we instead just choose the first and add everything to that
+			const appId =
+				uuidGroups[uuid].services[0]?.appId ||
+				uuidGroups[uuid].networks[0]?.appId ||
+				uuidGroups[uuid].volumes[0]?.appId;
+			grouping[appId] = uuidGroups[uuid];
+		}
+	} else {
+		// Otherwise group them by appId and let the state engine match them later.
+		// This will only happen once, as every target state going forward will
+		// contain UUIDs, we just need to handle the initial upgrade
+		const appSvcs = _.groupBy(services, 'appId');
+		const appVols = _.groupBy(volumes, 'appId');
+		const appNets = _.groupBy(networks, 'appId');
+
+		_.uniq(allAppIds).forEach((appId) => {
+			grouping[appId].services = grouping[appId].services.concat(
+				appSvcs[appId] || [],
+			);
+			grouping[appId].networks = grouping[appId].networks.concat(
+				appNets[appId] || [],
+			);
+			grouping[appId].volumes = grouping[appId].volumes.concat(
+				appVols[appId] || [],
+			);
+		});
+	}
+
+	return grouping;
 }
 
 function killServicesUsingApi(current: InstancedAppState): CompositionStep[] {
@@ -465,7 +582,11 @@ export async function setTarget(
 				// Currently this will only happen if the release
 				// which would replace it fails a contract
 				// validation check
-				_.map(apps, (_v, appId) => checkInt(appId)),
+				_.map(apps, (a) => checkInt(a.appId)),
+			)
+			.whereNotIn(
+				'uuid',
+				_.map(apps, (_a, uuid) => uuid),
 			)
 			.del();
 		await proxyvisor.setTargetInTransaction(dependent, trx);
@@ -731,6 +852,7 @@ function saveAndRemoveImages(
 					name: proxyvisorImage,
 				}),
 			);
+			// TODO: possibly add hostapps and supervisor to these filter
 			return notUsedForDelta && notUsedByProxyvisor;
 		},
 	);
@@ -787,6 +909,7 @@ export async function getStatus() {
 		if (!appId) {
 			continue;
 		}
+
 		if (apps[appId] == null) {
 			apps[appId] = {};
 		}
@@ -824,6 +947,7 @@ export async function getStatus() {
 
 	for (const image of images) {
 		const { appId } = image;
+
 		if (!image.dependent) {
 			if (apps[appId] == null) {
 				apps[appId] = {};

--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -235,7 +235,6 @@ export async function getRequiredSteps(
 
 		// We want to remove images before moving on to anything else
 		if (steps.length === 0) {
-			// TODO: this should be comparing by uuid if available
 			const targetAndCurrent = _.intersection(currentAppIds, targetAppIds);
 			const onlyTarget = _.difference(targetAppIds, currentAppIds);
 			const onlyCurrent = _.difference(currentAppIds, targetAppIds);

--- a/src/compose/images.ts
+++ b/src/compose/images.ts
@@ -373,6 +373,7 @@ async function getImagesForCleanup(): Promise<string[]> {
 			.then((vals) => vals.map((img: Image) => img.dockerImageId)),
 	]);
 
+	// TODO: this doesn't work anymore with registry managed supervisor
 	const supervisorRepos = [supervisorImageInfo.imageName];
 	// If we're on the new balena/ARCH-supervisor image
 	if (_.startsWith(supervisorImageInfo.imageName, 'balena/')) {

--- a/src/compose/images.ts
+++ b/src/compose/images.ts
@@ -90,7 +90,13 @@ export const initialized = (async () => {
 
 type ServiceInfo = Pick<
 	Service,
-	'imageName' | 'appId' | 'serviceId' | 'serviceName' | 'imageId' | 'releaseId'
+	| 'imageName'
+	| 'appId'
+	| 'uuid'
+	| 'serviceId'
+	| 'serviceName'
+	| 'imageId'
+	| 'releaseId'
 >;
 export function imageFromService(service: ServiceInfo): Image {
 	// We know these fields are defined because we create these images from target state

--- a/src/compose/network.ts
+++ b/src/compose/network.ts
@@ -16,6 +16,7 @@ export class Network {
 	public appId: number;
 	public name: string;
 	public config: NetworkConfig;
+	public uuid?: string;
 
 	private constructor() {}
 
@@ -57,12 +58,15 @@ export class Network {
 			options: network.Options ?? {},
 		};
 
+		ret.uuid = ret.config.labels['io.balena.app-uuid'];
+
 		return ret;
 	}
 
 	public static fromComposeObject(
 		name: string,
 		appId: number,
+		uuid: string,
 		network: Partial<Omit<ComposeNetworkConfig, 'ipam'>> & {
 			ipam?: Partial<ComposeNetworkConfig['ipam']>;
 		},
@@ -99,7 +103,11 @@ export class Network {
 			options: network.driver_opts || {},
 		};
 
-		net.config.labels = ComposeUtils.normalizeLabels(net.config.labels);
+		net.config.labels = {
+			...ComposeUtils.normalizeLabels(net.config.labels),
+			'io.balena.app-uuid': uuid,
+		};
+		net.uuid = uuid;
 
 		return net;
 	}

--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -46,9 +46,11 @@ export class Service {
 	public config: ServiceConfig;
 	public serviceName: string | null;
 	public releaseId: number;
+	public releaseVersion: string;
 	public serviceId: number;
 	public imageName: string | null;
 	public containerId: string | null;
+	public uuid: string | null;
 
 	public dependsOn: string[] | null;
 
@@ -126,6 +128,8 @@ export class Service {
 		delete appConfig.appId;
 		service.releaseId = parseInt(appConfig.releaseId, 10);
 		delete appConfig.releaseId;
+		service.releaseVersion = appConfig.releaseVersion;
+		delete appConfig.releaseVersion;
 		service.serviceId = parseInt(appConfig.serviceId, 10);
 		delete appConfig.serviceId;
 		service.imageName = appConfig.image;
@@ -133,6 +137,8 @@ export class Service {
 		delete appConfig.dependsOn;
 		service.createdAt = appConfig.createdAt;
 		delete appConfig.createdAt;
+		service.uuid = appConfig.uuid;
+		delete appConfig.uuid;
 
 		delete appConfig.contract;
 
@@ -271,6 +277,8 @@ export class Service {
 				service.appId || 0,
 				service.serviceId || 0,
 				service.serviceName || '',
+				service.uuid || undefined,
+				service.releaseVersion,
 			),
 		);
 
@@ -589,9 +597,12 @@ export class Service {
 				`Found a service with no appId! ${svc}`,
 			);
 		}
+
 		svc.appId = appId;
+		svc.uuid = svc.config.labels['io.balena.app-uuid'];
 		svc.serviceName = svc.config.labels['io.balena.service-name'];
 		svc.serviceId = parseInt(svc.config.labels['io.balena.service-id'], 10);
+		svc.releaseVersion = svc.config.labels['io.balena.release-version'];
 		if (Number.isNaN(svc.serviceId)) {
 			throw new InternalInconsistencyError(
 				'Attempt to build Service class from container with malformed labels',
@@ -1046,13 +1057,27 @@ export class Service {
 		appId: number,
 		serviceId: number,
 		serviceName: string,
+		uuid?: string,
+		releaseVersion?: string,
 	): { [labelName: string]: string } {
-		let newLabels = _.defaults(labels, {
-			'io.balena.supervised': 'true',
-			'io.balena.app-id': appId.toString(),
-			'io.balena.service-id': serviceId.toString(),
-			'io.balena.service-name': serviceName,
-		});
+		let newLabels = {
+			...labels,
+			...{
+				'io.balena.supervised': 'true',
+				'io.balena.app-id': appId.toString(),
+				'io.balena.service-id': serviceId.toString(),
+				'io.balena.service-name': serviceName,
+			},
+			// Set a uuid label if we have one
+			// uuid and releaseVersion will become mandatory in next major
+			// supervisor version
+			...(uuid != null ? { 'io.balena.app-uuid': uuid } : {}),
+
+			// Set a releaseVersion label if we have one
+			...(releaseVersion != null
+				? { 'io.balena.release-version': releaseVersion }
+				: {}),
+		};
 
 		const imageLabels = _.get(imageInfo, 'Config.Labels', {});
 		newLabels = _.defaults(newLabels, imageLabels);

--- a/src/compose/types/service.ts
+++ b/src/compose/types/service.ts
@@ -186,7 +186,7 @@ export interface DeviceMetadata {
 	imageInfo?: Dockerode.ImageInspectInfo;
 	uuid: string | null;
 	appName: string;
-	version: string;
+	version: string; // TODO: this is not used anywhere
 	deviceType: string;
 	deviceArch: string;
 	deviceApiKey: string;

--- a/src/compose/volume-manager.ts
+++ b/src/compose/volume-manager.ts
@@ -102,7 +102,15 @@ export async function createFromPath(
 	config: Partial<VolumeConfig>,
 	oldPath: string,
 ): Promise<Volume> {
-	const volume = Volume.fromComposeObject(name, appId, config);
+	const volume = Volume.fromComposeObject(
+		name,
+		appId,
+		// We don't have a uuid available here, but we need one to create a volume
+		// from a compose object. We pass uuid as undefined here so that we will
+		// fallback to id comparison for apps
+		undefined as any,
+		config,
+	);
 
 	await create(volume);
 	const inspect = await docker

--- a/src/device-state.ts
+++ b/src/device-state.ts
@@ -567,22 +567,23 @@ export async function getStatus(): Promise<DeviceStatus> {
 	theState.local!.apps = appsStatus.local;
 	theState.dependent!.apps = appsStatus.dependent;
 
-	// Multi-app warning!
-	// If we have more than one app, simply return the first commit.
-	// Fortunately this won't become a problem until we have system apps, and then
-	// at that point we can filter non-system apps leaving a single user app.
-	// After this, for true multi-app, we will need to report our status back in a
-	// different way, meaning this function will no longer be needed
 	const appIds = Object.keys(theState.local!.apps).map((strId) =>
 		parseInt(strId, 10),
 	);
 
-	const appId: number | undefined = appIds[0];
-	if (appId != null) {
+	// Multi-app warning!
+	// For v3 target state endpoint we are moving away from is_on__commit (device level) to
+	// a is_running__release app level field.
+	// Only the commit for the user app will be stored for now but that will go away once
+	// we move to full multi-app. At that point we'll have to decide what to do with
+	// the `/v1/device` endpoint, since that is the only place that actually reports the commit
+	// When we deprecate v1 endpoints we will no longer have that problem.
+	for (const appId of appIds) {
 		const commit = await commitStore.getCommitForApp(appId);
 
 		if (commit != null && !applyInProgress) {
 			theState.local!.is_on__commit = commit;
+			break;
 		}
 	}
 

--- a/src/device-state/preload.ts
+++ b/src/device-state/preload.ts
@@ -42,22 +42,25 @@ export async function loadTargetFromFile(
 		const preloadState = stateFromFile as AppsJsonFormat;
 
 		let commitToPin: string | undefined;
-		let appToPin: string | undefined;
+		let appToPin: number | undefined;
 
 		if (_.isEmpty(preloadState)) {
 			return;
 		}
 
 		const imgs: Image[] = [];
-		const appIds = _.keys(preloadState.apps);
-		for (const appId of appIds) {
-			const app = preloadState.apps[appId];
+		const uuids = _.keys(preloadState.apps);
+
+		for (const uuid of uuids) {
+			const app = preloadState.apps[uuid];
+
 			// Multi-app warning!
 			// The following will need to be changed once running
 			// multiple applications is possible
 			commitToPin = app.commit;
-			appToPin = appId;
+			appToPin = app.appId;
 			const serviceIds = _.keys(app.services);
+
 			for (const serviceId of serviceIds) {
 				const service = app.services[serviceId];
 				const svc = {
@@ -66,7 +69,8 @@ export async function loadTargetFromFile(
 					imageId: service.imageId,
 					serviceId: parseInt(serviceId, 10),
 					releaseId: app.releaseId,
-					appId: parseInt(appId, 10),
+					appId: app.appId,
+					uuid,
 				};
 				imgs.push(imageFromService(svc));
 			}
@@ -97,7 +101,7 @@ export async function loadTargetFromFile(
 				await config.set({
 					pinDevice: {
 						commit: commitToPin,
-						app: parseInt(appToPin, 10),
+						app: appToPin,
 					},
 				});
 			}

--- a/src/device-state/preload.ts
+++ b/src/device-state/preload.ts
@@ -63,6 +63,7 @@ export async function loadTargetFromFile(
 
 			for (const serviceId of serviceIds) {
 				const service = app.services[serviceId];
+
 				const svc = {
 					imageName: service.image,
 					serviceName: service.serviceName,
@@ -79,7 +80,11 @@ export async function loadTargetFromFile(
 		for (const image of imgs) {
 			const name = await images.normalise(image.name);
 			image.name = name;
-			await images.save(image);
+			// TODO: the only reason for adding the images to the database here
+			// is to prevent downloading images if for any reason they are not there
+			// when starting from a preloading state. But if they are not there, isn't
+			// that really a preload issue?
+			// await images.save(image);
 		}
 
 		const deviceConf = await deviceConfig.getCurrent();

--- a/src/device-state/target-state-cache.ts
+++ b/src/device-state/target-state-cache.ts
@@ -8,12 +8,15 @@ import * as db from '../db';
 export interface DatabaseApp {
 	name: string;
 	releaseId: number;
+	releaseVersion: string;
 	commit: string;
 	appId: number;
+	isHost?: boolean;
 	services: string;
 	networks: string;
 	volumes: string;
 	source: string;
+	uuid: string;
 }
 export type DatabaseApps = DatabaseApp[];
 
@@ -75,6 +78,12 @@ export async function setTargetApps(
 	targetState = undefined;
 
 	await Promise.all(
-		apps.map((app) => db.upsertModel('app', app, { appId: app.appId }, trx)),
+		apps.map((app) => {
+			if (app.uuid) {
+				db.upsertModel('app', app, { uuid: app.uuid }, trx);
+			} else {
+				db.upsertModel('app', app, { appId: app.appId }, trx);
+			}
+		}),
 	);
 }

--- a/src/device-state/target-state.ts
+++ b/src/device-state/target-state.ts
@@ -135,7 +135,7 @@ export const update = async (
 			);
 		}
 
-		const endpoint = url.resolve(apiEndpoint, `/device/v2/${uuid}/state`);
+		const endpoint = url.resolve(apiEndpoint, `/device/v3/${uuid}/state`);
 		const request = await getRequestInstance();
 
 		const params: CoreOptions = {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,7 +9,8 @@ const constants = {
 	rootMountPoint,
 	databasePath:
 		checkString(process.env.DATABASE_PATH) || '/data/database.sqlite',
-	containerId: checkString(process.env.SUPERVISOR_CONTAINER_ID) || undefined,
+	containerId:
+		checkString(process.env.SUPERVISOR_CONTAINER_ID) || 'balena_supervisor',
 	dockerSocket: process.env.DOCKER_SOCKET || '/var/run/docker.sock',
 
 	// In-container location for docker socket

--- a/src/lib/migration.ts
+++ b/src/lib/migration.ts
@@ -34,7 +34,7 @@ export const defaultLegacyVolume = () => 'resin-data';
 
 export function singleToMulticontainerApp(
 	app: Dictionary<any>,
-): TargetApplication & { appId: string } {
+): TargetApplication {
 	const environment: Dictionary<string> = {};
 	for (const key in app.env) {
 		if (!/^RESIN_/.test(key)) {
@@ -44,11 +44,12 @@ export function singleToMulticontainerApp(
 
 	const { appId } = app;
 	const conf = app.config != null ? app.config : {};
-	const newApp: TargetApplication & { appId: string } = {
-		appId: appId.toString(),
+	const newApp: TargetApplication = {
+		appId,
 		commit: app.commit,
 		name: app.name,
 		releaseId: 1,
+		releaseVersion: app.commit,
 		networks: {},
 		volumes: {},
 		services: {},

--- a/src/lib/supervisor-metadata.ts
+++ b/src/lib/supervisor-metadata.ts
@@ -1,0 +1,36 @@
+import * as memoizee from 'memoizee';
+import { docker } from '../lib/docker-utils';
+import * as constants from '../lib/constants';
+import log from './supervisor-console';
+
+export type SupervisorMetadata = {
+	uuid?: string;
+	serviceName?: string;
+};
+
+/**
+ * Get the metadata from the supervisor container
+ *
+ * This is needed for the supervisor to identify itself on the target
+ * state and on getStatus() in device-state.ts
+ *
+ * TODO: remove this once the supervisor knows how to update itself
+ */
+export const getSupervisorMetadata = memoizee(async () => {
+	const supervisorService: SupervisorMetadata = {};
+
+	try {
+		const container = await docker
+			.getContainer(constants.containerId)
+			.inspect();
+
+		const { Labels } = container.Config;
+		supervisorService.uuid = Labels['io.balena.app-uuid'];
+		supervisorService.serviceName = Labels['io.balena.service-name'];
+	} catch (e) {
+		log.warn(
+			`Failed to query supervisor container with id ${constants.containerId}`,
+		);
+	}
+	return supervisorService;
+});

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -377,11 +377,11 @@ export function isValidAppsObject(obj: any): boolean {
 		return false;
 	}
 
-	return _.every(obj, (v, appId) => {
-		if (!isValidShortText(appId) || !checkInt(appId)) {
+	return _.every(obj, (v, uuid) => {
+		if (!isValidShortText(uuid)) {
 			log.debug(
-				'Invalid appId passed to validation.isValidAppsObject\nApp ID:',
-				inspect(appId),
+				'Invalid UUID passed to validation.isValidAppsObject\nUUID:',
+				inspect(uuid),
 			);
 			return false;
 		}
@@ -398,6 +398,16 @@ export function isValidAppsObject(obj: any): boolean {
 					log.debug(
 						'Invalid service name passed to validation.isValidAppsObject\nName:',
 						inspect(n),
+					);
+					return false;
+				}
+				return true;
+			},
+			appId: (id: any) => {
+				if (id != null && checkInt(id) == null) {
+					log.debug(
+						'Invalid appId passed to validation.isValidAppsObject\nApp ID',
+						inspect(id),
 					);
 					return false;
 				}
@@ -454,7 +464,7 @@ export function isValidDependentDevicesObject(devices: any): boolean {
 	return _.every(devices, (val, uuid) => {
 		if (!isValidShortText(uuid)) {
 			log.debug(
-				'Invalid uuid passed to validation.isValidDependentDevicesObject\nuuid:',
+				'Invalid UUID passed to validation.isValidDependentDevicesObject\nUUID:',
 				inspect(uuid),
 			);
 			return false;

--- a/src/migrations/M00007.js
+++ b/src/migrations/M00007.js
@@ -1,0 +1,12 @@
+export async function up(knex) {
+	await knex.schema.table('app', (table) => {
+		table.string('uuid');
+		table.unique('uuid');
+		table.boolean('isHost').defaultTo(false);
+		table.string('releaseVersion');
+	});
+}
+
+export async function down() {
+	throw new Error('Not implemented');
+}

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -53,10 +53,13 @@ export interface TargetState {
 		name: string;
 		config: EnvVarObject;
 		apps: {
-			[appId: string]: {
+			[uuid: string]: {
+				appId: number;
 				name: string;
 				commit: string;
 				releaseId: number;
+				releaseVersion: string;
+				isHost?: boolean;
 				services: {
 					[serviceId: string]: {
 						labels: LabelObject;

--- a/test/05-device-state.spec.ts
+++ b/test/05-device-state.spec.ts
@@ -37,10 +37,12 @@ const testTarget2 = {
 			RESIN_HOST_CONFIG_gpu_mem: '512',
 		},
 		apps: {
-			'1234': {
+			'test-uuid': {
 				name: 'superapp',
+				appId: 1234,
 				commit: 'afafafa',
 				releaseId: 2,
+				releaseVersion: '1.5.1',
 				services: {
 					'23': {
 						serviceName: 'aservice',
@@ -100,11 +102,11 @@ const testTargetWithDefaults2 = {
 				services: [
 					_.merge(
 						{ appId: 1234, serviceId: 23, releaseId: 2 },
-						_.clone(testTarget2.local.apps['1234'].services['23']),
+						_.clone(testTarget2.local.apps['test-uuid'].services['23']),
 					),
 					_.merge(
 						{ appId: 1234, serviceId: 24, releaseId: 2 },
-						_.clone(testTarget2.local.apps['1234'].services['24']),
+						_.clone(testTarget2.local.apps['test-uuid'].services['24']),
 					),
 				],
 				volumes: {},

--- a/test/06-validation.spec.ts
+++ b/test/06-validation.spec.ts
@@ -166,8 +166,9 @@ describe('validation', () => {
 	describe('isValidAppsObject', () => {
 		it('returns true for a valid object', () => {
 			const apps = {
-				'1234': {
+				uuid: {
 					name: 'something',
+					appId: 1234,
 					releaseId: 123,
 					commit: 'bar',
 					services: {
@@ -188,6 +189,7 @@ describe('validation', () => {
 			const apps = {
 				'1234': {
 					name: 'something',
+					appId: 1234,
 					releaseId: 123,
 					commit: 'bar',
 					services: {
@@ -206,8 +208,9 @@ describe('validation', () => {
 
 		it('returns false with an invalid appId', () => {
 			const apps = {
-				boo: {
+				uuid: {
 					name: 'something',
+					appId: 'test',
 					releaseId: 123,
 					commit: 'bar',
 					services: {
@@ -228,6 +231,7 @@ describe('validation', () => {
 			const apps = {
 				'1234': {
 					name: 'something',
+					appId: 1234,
 					services: {
 						'45': {
 							serviceName: 'bazbaz',

--- a/test/13-application-manager.spec.ts
+++ b/test/13-application-manager.spec.ts
@@ -109,10 +109,20 @@ describe.skip('ApplicationManager', function () {
 						Service.fromComposeObject(svc, { appName: 'test' }),
 					),
 					networks: _.mapValues(app.networks, (conf, name) =>
-						Network.fromComposeObject(name, parseInt(appId, 10), conf),
+						Network.fromComposeObject(
+							name,
+							parseInt(appId, 10),
+							'test-uuid',
+							conf,
+						),
 					),
 					volumes: _.mapValues(app.volumes, (conf, name) =>
-						Volume.fromComposeObject(name, parseInt(appId, 10), conf),
+						Volume.fromComposeObject(
+							name,
+							parseInt(appId, 10),
+							'test-uuid',
+							conf,
+						),
 					),
 				};
 				currentCloned.local.apps[parseInt(appId, 10)] = appCloned;
@@ -542,7 +552,7 @@ describe.skip('ApplicationManager', function () {
 				Bluebird.Promise.resolve([
 					{
 						action: 'removeVolume',
-						current: Volume.fromComposeObject('my_volume', 12, {}),
+						current: Volume.fromComposeObject('my_volume', 12, 'test-uuid', {}),
 					},
 				]),
 			);

--- a/test/20-compose-volume.spec.ts
+++ b/test/20-compose-volume.spec.ts
@@ -53,14 +53,19 @@ describe('Compose volumes', () => {
 		});
 
 		it('should correctly parse compose volumes without an explicit driver', () => {
-			const volume = Volume.fromComposeObject('one_volume', 1032480, {
-				driver_opts: {
-					opt1: 'test',
+			const volume = Volume.fromComposeObject(
+				'one_volume',
+				1032480,
+				'test-uuid',
+				{
+					driver_opts: {
+						opt1: 'test',
+					},
+					labels: {
+						'my-label': 'test-label',
+					},
 				},
-				labels: {
-					'my-label': 'test-label',
-				},
-			});
+			);
 
 			expect(volume).to.have.property('appId').that.equals(1032480);
 			expect(volume).to.have.property('name').that.equals('one_volume');
@@ -70,6 +75,7 @@ describe('Compose volumes', () => {
 				.that.deep.equals({
 					'io.balena.supervised': 'true',
 					'my-label': 'test-label',
+					'io.balena.app-uuid': 'test-uuid',
 				});
 			expect(volume)
 				.to.have.property('config')
@@ -84,15 +90,20 @@ describe('Compose volumes', () => {
 		});
 
 		it('should correctly parse compose volumes with an explicit driver', () => {
-			const volume = Volume.fromComposeObject('one_volume', 1032480, {
-				driver: 'other',
-				driver_opts: {
-					opt1: 'test',
+			const volume = Volume.fromComposeObject(
+				'one_volume',
+				1032480,
+				'test-uuid',
+				{
+					driver: 'other',
+					driver_opts: {
+						opt1: 'test',
+					},
+					labels: {
+						'my-label': 'test-label',
+					},
 				},
-				labels: {
-					'my-label': 'test-label',
-				},
-			});
+			);
 
 			expect(volume).to.have.property('appId').that.equals(1032480);
 			expect(volume).to.have.property('name').that.equals('one_volume');
@@ -102,6 +113,7 @@ describe('Compose volumes', () => {
 				.that.deep.equals({
 					'io.balena.supervised': 'true',
 					'my-label': 'test-label',
+					'io.balena.app-uuid': 'test-uuid',
 				});
 			expect(volume)
 				.to.have.property('config')
@@ -123,14 +135,19 @@ describe('Compose volumes', () => {
 			logMessageStub.reset();
 		});
 		it('should correctly generate docker options', async () => {
-			const volume = Volume.fromComposeObject('one_volume', 1032480, {
-				driver_opts: {
-					opt1: 'test',
+			const volume = Volume.fromComposeObject(
+				'one_volume',
+				1032480,
+				'test-uuid',
+				{
+					driver_opts: {
+						opt1: 'test',
+					},
+					labels: {
+						'my-label': 'test-label',
+					},
 				},
-				labels: {
-					'my-label': 'test-label',
-				},
-			});
+			);
 
 			await volume.create();
 			expect(
@@ -138,6 +155,7 @@ describe('Compose volumes', () => {
 					Labels: {
 						'my-label': 'test-label',
 						'io.balena.supervised': 'true',
+						'io.balena.app-uuid': 'test-uuid',
 					},
 					Options: {
 						opt1: 'test',

--- a/test/28-db-format.spec.ts
+++ b/test/28-db-format.spec.ts
@@ -12,9 +12,9 @@ import Service from '../src/compose/service';
 import Network from '../src/compose/network';
 import { TargetApplication } from '../src/types/state';
 
-function getDefaultNetworks(appId: number) {
+function getDefaultNetworks(appId: number, uuid: string) {
 	return {
-		default: Network.fromComposeObject('default', appId, {}),
+		default: Network.fromComposeObject('default', appId, uuid, {}),
 	};
 }
 
@@ -39,20 +39,24 @@ describe('DB Format', () => {
 		await targetStateCache.setTargetApps([
 			{
 				appId: 1,
+				uuid: 'test-uuid1',
 				commit: 'abcdef',
 				name: 'test-app',
 				source: apiEndpoint,
 				releaseId: 123,
+				releaseVersion: '1.5.1',
 				services: '[]',
 				networks: '[]',
 				volumes: '[]',
 			},
 			{
 				appId: 2,
+				uuid: 'test-uuid2',
 				commit: 'abcdef2',
 				name: 'test-app2',
 				source: apiEndpoint,
 				releaseId: 1232,
+				releaseVersion: '0.5.1',
 				services: JSON.stringify([
 					{
 						serviceName: 'test-service',
@@ -95,7 +99,7 @@ describe('DB Format', () => {
 		expect(app).to.have.property('volumes').that.deep.equals({});
 		expect(app)
 			.to.have.property('networks')
-			.that.deep.equals(getDefaultNetworks(1));
+			.that.deep.equals(getDefaultNetworks(1, 'test-uuid1'));
 	});
 
 	it('should correctly build services from the database', async () => {
@@ -126,7 +130,7 @@ describe('DB Format', () => {
 		const target = await import('./data/state-endpoints/simple.json');
 		const dbApps: { [appId: number]: TargetApplication } = {};
 		dbApps[1234] = {
-			...target.local.apps[1234],
+			...target.local.apps['test-uuid'],
 		};
 
 		await dbFormat.setApps(dbApps, apiEndpoint);

--- a/test/32-compose-app-manager.spec.ts
+++ b/test/32-compose-app-manager.spec.ts
@@ -169,11 +169,12 @@ describe('compose/application-manager', () => {
 					SUPERVISOR_PERSISTENT_LOGGING: 'false',
 				},
 				apps: {
-					'1': {
+					'test-uuid': {
 						appId: 1,
 						name: 'userapp',
 						commit: 'aaaaaaa',
 						releaseId: 1,
+						releaseVersion: '2.2.2',
 						services: {
 							'1': {
 								serviceName: 'mainy-1-servicey',
@@ -186,11 +187,12 @@ describe('compose/application-manager', () => {
 						volumes: {},
 						networks: {},
 					},
-					'100': {
+					'test-uuid2': {
 						appId: 100,
 						name: 'systemapp',
 						commit: 'bbbbbbb',
 						releaseId: 100,
+						releaseVersion: '0.2.2',
 						services: {
 							'100': {
 								serviceName: 'mainy-2-systemapp',

--- a/test/34-firewall.spec.ts
+++ b/test/34-firewall.spec.ts
@@ -6,6 +6,7 @@ import { docker } from '../src/lib/docker-utils';
 import * as sinon from 'sinon';
 
 import * as config from '../src/config';
+import * as db from '../src/db';
 import * as firewall from '../src/lib/firewall';
 import * as logger from '../src/logger';
 import * as iptablesMock from './lib/mocked-iptables';
@@ -39,6 +40,9 @@ describe('Host Firewall', function () {
 				return {};
 			},
 		} as Docker.Image);
+
+		await db.initialized;
+		await db.models('app').del();
 
 		await targetStateCache.initialized;
 		await firewall.initialised;
@@ -161,10 +165,12 @@ describe('Host Firewall', function () {
 					await targetStateCache.setTargetApps([
 						{
 							appId: 2,
+							uuid: 'test-uuid',
 							commit: 'abcdef2',
 							name: 'test-app2',
 							source: apiEndpoint,
 							releaseId: 1232,
+							releaseVersion: '0.1.1',
 							services: JSON.stringify([
 								{
 									serviceName: 'test-service',
@@ -213,10 +219,12 @@ describe('Host Firewall', function () {
 					await targetStateCache.setTargetApps([
 						{
 							appId: 2,
+							uuid: 'test-uuid2',
 							commit: 'abcdef2',
 							name: 'test-app2',
 							source: apiEndpoint,
 							releaseId: 1232,
+							releaseVersion: '0.1.1',
 							services: JSON.stringify([
 								{
 									serviceName: 'test-service',

--- a/test/40-app-uuids.spec.ts
+++ b/test/40-app-uuids.spec.ts
@@ -1,0 +1,241 @@
+import { promises as fs } from 'fs';
+import * as mockedDockerode from './lib/mocked-dockerode';
+import { expect } from 'chai';
+import * as appMock from './lib/application-state-mock';
+import { createService } from './lib/compose-helpers';
+
+import * as db from '../src/db';
+import * as dbFormat from '../src/device-state/db-format';
+import * as deviceState from '../src/device-state';
+import * as applicationManager from '../src/compose/application-manager';
+import supervisorVersion = require('../src/lib/supervisor-version');
+import { intialiseContractRequirements } from '../src/lib/contracts';
+import { TargetState } from '../src/types/state';
+import Volume from '../src/compose/volume';
+import Network from '../src/compose/network';
+
+describe('App UUIDs', () => {
+	let uuidTargetState: TargetState;
+	let uuidTestUuid: string;
+	let uuidTestReleaseVersion: string;
+	let uuidTestAppId: number;
+
+	before(async () => {
+		uuidTargetState = JSON.parse(
+			await fs.readFile(
+				require.resolve('./data/uuid-target-state.json'),
+				'utf-8',
+			),
+		);
+		uuidTestUuid = Object.keys(uuidTargetState.local.apps)[0];
+		uuidTestReleaseVersion =
+			uuidTargetState.local.apps[uuidTestUuid].releaseVersion;
+		uuidTestAppId = uuidTargetState.local.apps[uuidTestUuid].appId;
+
+		mockedDockerode.registerOverride('getImage', () => {
+			return {
+				inspect: async () => {
+					/* noop */
+				},
+			} as any;
+		});
+
+		await db.initialized;
+		await applicationManager.initialized;
+		intialiseContractRequirements({
+			supervisorVersion,
+			deviceType: 'intel-nuc',
+			l4tVersion: '32.2',
+		});
+	});
+
+	describe('Target state', () => {
+		before(async () => {
+			await db.models('app').del();
+		});
+		it('should correctly validate apps keyed by UUID', async () => {
+			// Reject v2 target states
+			await expect(
+				deviceState.setTarget({
+					local: {
+						name: 'some-name',
+						config: {},
+						apps: {
+							'1': {
+								name: 'pi4test',
+								commit: 'c23e5a0f49d31ea8ca2a4866e1ba8482',
+								releaseId: 1551563,
+								services: {},
+								volumes: {},
+								networks: {},
+							},
+						},
+					},
+				} as any),
+			).to.be.rejected;
+			await expect(deviceState.setTarget(uuidTargetState)).to.not.be.rejected;
+		});
+
+		it('should correctly set the UUID and appId in the database', async () => {
+			await deviceState.setTarget(uuidTargetState);
+			const apps = await db.models('app').select();
+
+			expect(apps).to.have.length(1);
+			expect(apps[0]).to.have.property('uuid').that.equals(uuidTestUuid);
+			expect(apps[0])
+				.to.have.property('releaseVersion')
+				.that.equals(uuidTestReleaseVersion);
+			expect(apps[0]).to.have.property('appId').that.equals(uuidTestAppId);
+		});
+
+		it('should correctly build an app with a UUID, appId and type from target state', async () => {
+			await deviceState.setTarget(uuidTargetState);
+
+			const apps = Object.values(await dbFormat.getApps());
+			expect(apps).to.have.length(1);
+			expect(apps[0]).to.have.property('uuid').that.equals(uuidTestUuid);
+		});
+
+		it('should generate a container config with a UUID', async () => {
+			const service = await createService(
+				{},
+				123,
+				'test',
+				123,
+				123,
+				123,
+				'test-uuid',
+			);
+			expect(service.toDockerContainer({} as any))
+				.that.has.property('Labels')
+				.that.has.property('io.balena.app-uuid')
+				.that.equals('test-uuid');
+		});
+
+		it('should generate a volume config with a UUID', () => {
+			const volume = Volume.fromComposeObject('test', 123, 'test-uuid', {});
+
+			expect(volume.toDockerVolume())
+				.to.have.property('Labels')
+				.that.has.property('io.balena.app-uuid')
+				.that.equals('test-uuid');
+		});
+
+		it('should generate a network config with a UUID', () => {
+			const network = Network.fromComposeObject('test', 1234, 'test-uuid', {});
+
+			expect(network.toDockerConfig())
+				.to.have.property('Labels')
+				.that.has.property('io.balena.app-uuid')
+				.that.equals('test-uuid');
+		});
+	});
+
+	describe('Current state', () => {
+		it('should group components by uuid if possible', async () => {
+			appMock.mockManagers(
+				[
+					await createService({}, 1234, 'test', 1234, 1234, 1234, 'test-uuid'),
+					await createService({}, 2345, 'test', 1234, 1234, 1234, 'test-uuid'),
+				],
+				[],
+				[],
+			);
+
+			expect(
+				Object.keys(await applicationManager.getCurrentApps()),
+			).to.have.length(1);
+
+			appMock.mockManagers(
+				[],
+				[
+					Volume.fromComposeObject('test', 123, 'test-uuid', {}),
+					Volume.fromComposeObject('test2', 124, 'test-uuid', {}),
+				],
+				[],
+			);
+
+			expect(
+				Object.keys(await applicationManager.getCurrentApps()),
+			).to.have.length(1);
+
+			appMock.mockManagers(
+				[],
+				[],
+				[
+					Network.fromComposeObject('test', 123, 'test-uuid', {}),
+					Network.fromComposeObject('test2', 256, 'test-uuid', {}),
+				],
+			);
+			expect(
+				Object.keys(await applicationManager.getCurrentApps()),
+			).to.have.length(1);
+
+			appMock.mockManagers(
+				[await createService({}, 1234, 'test', 1234, 1234, 1234, 'test-uuid')],
+				[Volume.fromComposeObject('test', 234, 'test-uuid', {})],
+				[Network.fromComposeObject('test2', 256, 'test-uuid', {})],
+			);
+			expect(
+				Object.keys(await applicationManager.getCurrentApps()),
+			).to.have.length(1);
+		});
+
+		it('should fall back to grouping by appId when no uuid is present', async () => {
+			appMock.mockManagers(
+				[await createService({}, 1234, 'test', 1234, 1234, 1234)],
+				[Volume.fromComposeObject('test', 1234, 'test-uuid', {})],
+				[Network.fromComposeObject('test2', 1234, 'test-uuid', {})],
+			);
+
+			expect(Object.keys(await applicationManager.getCurrentApps()));
+		});
+
+		it('should populate a UUID in an app', async () => {
+			appMock.unmockAll();
+			mockedDockerode.registerOverride('listContainers', async () => {
+				return [
+					{
+						Id: 'container1',
+						Labels: {
+							'io.balena.app-id': '1623449',
+							'io.balena.supervised': 'true',
+							'io.balena.service-name': 'main',
+							'io.balena.service-id': '482141',
+							'io.balena.app-uuid': uuidTestUuid,
+						},
+					},
+				] as any;
+			});
+			mockedDockerode.registerOverride('getContainer', ((_name: string) => {
+				return {
+					inspect: async () => ({
+						State: {
+							Running: true,
+						},
+						Name: 'main_482141_1623449',
+						HostConfig: {},
+						Config: {
+							Labels: {
+								'io.balena.app-id': '1623449',
+								'io.balena.supervised': 'true',
+								'io.balena.service-name': 'main',
+								'io.balena.service-id': '482141',
+								'io.balena.app-uuid': uuidTestUuid,
+							},
+							Hostname: 'test',
+						},
+					}),
+				};
+			}) as any);
+
+			const currentState = await deviceState.getCurrentState();
+			const apps = Object.values(currentState.local.apps);
+			expect(apps).to.have.length(1);
+			expect(apps[0]).to.have.property('uuid').that.equals(uuidTestUuid);
+
+			mockedDockerode.restoreOverride('listContainers');
+			mockedDockerode.restoreOverride('getContainer');
+		});
+	});
+});

--- a/test/data/apps-pin.json
+++ b/test/data/apps-pin.json
@@ -5,7 +5,9 @@
 		"RESIN_HOST_LOG_TO_DISPLAY": "0"
 	},
 	"apps": {
-		"1234": {
+		"uuid": {
+			"appId": 1234,
+			"type": "supervised",
 			"name": "superapp",
 			"commit": "abcdef",
 			"releaseId": 1,

--- a/test/data/apps.json
+++ b/test/data/apps.json
@@ -5,10 +5,12 @@
 		"RESIN_HOST_LOG_TO_DISPLAY": "0"
 	},
 	"apps": {
-		"1234": {
+		"uuid": {
 			"name": "superapp",
+      "appId": "1234",
 			"commit": "abcdef",
 			"releaseId": 1,
+      "type": "supervised",
 			"services": {
 				"23": {
 					"imageId": 12345,

--- a/test/data/testconfig-uuid.json
+++ b/test/data/testconfig-uuid.json
@@ -1,0 +1,17 @@
+
+{
+	"applicationId": 78373,
+	"deviceType": "raspberrypi3",
+	"appUpdatePollInterval": 3000,
+	"listenPort": 2345,
+	"vpnPort": 443,
+	"registryEndpoint": "registry2.balena-cloud.com",
+	"deltaEndpoint": "https://delta.balena-cloud.com",
+	"mixpanelToken": "baz",
+	"version": "2.0.6+rev3.prod",
+	"uuid": "ae982813c41eec2bd0a391ef268de5a6",
+	"apiEndpoint": "https://api.balena-cloud.com",
+	"registered_at": 1234889324,
+	"deviceId": 3,
+	"deviceApiKey": "SuperSecretKey"
+}

--- a/test/data/uuid-target-state.json
+++ b/test/data/uuid-target-state.json
@@ -1,7 +1,6 @@
-
 {
   "local": {
-    "name": "lingering-frost",
+    "name": "white-tree",
     "config": {
       "RESIN_SUPERVISOR_DELTA_VERSION": "3",
       "RESIN_SUPERVISOR_NATIVE_LOGGER": "true",
@@ -11,17 +10,18 @@
       "RESIN_HOST_CONFIG_dtparam": "\"i2c_arm=on\",\"spi=on\",\"audio=on\"",
       "RESIN_HOST_CONFIG_enable_uart": "1",
       "RESIN_HOST_CONFIG_gpu_mem": "16",
+      "RESIN_HOST_FIREWALL_MODE": "",
       "RESIN_SUPERVISOR_DELTA": "1",
+      "RESIN_SUPERVISOR_LOCAL_MODE": "0",
       "RESIN_SUPERVISOR_POLL_INTERVAL": "900000"
     },
     "apps": {
-      "test-uuid": {
+      "mytestuuid": {
+        "appId": 1623449,
         "name": "pi4test",
-        "appId": 1234,
-        "type": "supervised",
-        "commit": "d0b7b1d5353c4a1d9d411614caf827f5",
-        "releaseId": 1405939,
-        "releaseVersion": "2.2.2",
+        "commit": "c23e5a0f49d31ea8ca2a4866e1ba8482",
+        "releaseId": 1551563,
+        "releaseVersion": "1.1.1",
         "services": {
           "482141": {
             "privileged": true,
@@ -38,9 +38,9 @@
               "io.resin.features.resin-api": "1",
               "io.resin.features.supervisor-api": "1"
             },
-            "imageId": 2339002,
+            "imageId": 2781425,
             "serviceName": "main",
-            "image": "registry2.balena-cloud.com/v2/f5aff5560e1fb6740a868bfe2e8a4684@sha256:9cd1d09aad181b98067dac95e08f121c3af16426f078c013a485c41a63dc035c",
+            "image": "registry2.balena-cloud.com/v2/eed0b001166e66b841336aba6ca7ea8f@sha256:5749b6b02f2bf475463cd63c5acf1aabb585313ff12769b5c2f7c3b23e73c6c7",
             "running": true,
             "environment": {}
           }

--- a/test/lib/application-state-mock.ts
+++ b/test/lib/application-state-mock.ts
@@ -42,7 +42,7 @@ function unmockManagers() {
 	// @ts-expect-error Assigning to a RO property
 	networkManager.getAll = originalNetGetAll;
 	// @ts-expect-error Assigning to a RO property
-	serviceManager.getall = originalSvcGetAll;
+	serviceManager.getAll = originalSvcGetAll;
 }
 
 export function mockImages(

--- a/test/lib/compose-helpers.ts
+++ b/test/lib/compose-helpers.ts
@@ -1,0 +1,60 @@
+import * as _ from 'lodash';
+import App from '../../src/compose/app';
+
+import Network from '../../src/compose/network';
+import Service from '../../src/compose/service';
+import { ServiceComposeConfig } from '../../src/compose/types/service';
+import Volume from '../../src/compose/volume';
+
+export function createApp(
+	services: Service[],
+	networks: Network[],
+	volumes: Volume[],
+	target: boolean,
+	appId = 1,
+) {
+	return new App(
+		{
+			appId,
+			services,
+			networks: _.keyBy(networks, 'name'),
+			volumes: _.keyBy(volumes, 'name'),
+		},
+		target,
+	);
+}
+
+export async function createService(
+	conf: Partial<ServiceComposeConfig>,
+	appId = 1,
+	serviceName = 'test',
+	releaseId = 2,
+	serviceId = 3,
+	imageId = 4,
+	uuid?: string,
+	extraState?: Partial<Service>,
+) {
+	if (uuid == null) {
+		// Now that we match on UUID, make sure previous tests don't break by having
+		// the uuid the same based on the appId
+		uuid = `uuid${appId}`;
+	}
+	const svc = await Service.fromComposeObject(
+		{
+			appId,
+			serviceName,
+			releaseId,
+			serviceId,
+			imageId,
+			uuid,
+			...conf,
+		},
+		{} as any,
+	);
+	if (extraState != null) {
+		for (const k of Object.keys(extraState)) {
+			(svc as any)[k] = (extraState as any)[k];
+		}
+	}
+	return svc;
+}

--- a/test/lib/mocked-dockerode.ts
+++ b/test/lib/mocked-dockerode.ts
@@ -44,7 +44,7 @@ for (const fn of Object.getOwnPropertyNames(dockerode.prototype)) {
 		fn !== 'constructor' &&
 		typeof (dockerode.prototype as any)[fn] === 'function'
 	) {
-		(dockerode.prototype as any)[fn] = async function (...args: any[]) {
+		(dockerode.prototype as any)[fn] = function (...args: any[]) {
 			console.log(`🐳  Calling ${fn}...`);
 			if (overrides[fn] != null) {
 				return overrides[fn](args);

--- a/test/lib/prepare.ts
+++ b/test/lib/prepare.ts
@@ -58,6 +58,10 @@ export = async function () {
 			'./test/data/config-apibinder-offline2.json',
 			fs.readFileSync('./test/data/testconfig-apibinder-offline2.json'),
 		);
+		fs.writeFileSync(
+			'./test/data/config-uuid.json',
+			fs.readFileSync('./test/data/testconfig-uuid.json'),
+		);
 	} catch (e) {
 		/* ignore /*/
 	}


### PR DESCRIPTION
We store the uuid and releaseVersion on the individual docker components so that when
building a current state, we can match them with the target state.

This only accepts uuids from the target state but appId and serviceId still
remain the main method for comparing current and target state

This is a breaking change that requires a new state endpoint version

See balena-io/open-balena-api#504

Change-type: major
Depends-on: balena-io/open-balena-api#504
Depends-on: #1676 