### PR TITLE
Added clean step to remove previous builds before running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "npm run release && webpack",
     "build:debug": "npm run release && npm run packagejson:copy",
     "lint": "balena-lint -e ts -e js --typescript src/ test/ typings/ build-utils/ webpack.config.js && tsc --noEmit && tsc --noEmit --project tsconfig.js.json",
-    "test": "npm run test-nolint",
+    "test": "npm run clean && npm run test-nolint",
     "posttest": "npm run lint",
     "test-nolint": "npm run test:build && TEST=1 mocha",
     "test:build": "npm run test-build && npm run testitems:copy && npm run packagejson:copy",
@@ -23,7 +23,8 @@
     "release": "tsc --project tsconfig.release.json && mv build/src/* build",
     "packagejson:copy": "cp package.json build/",
     "testitems:copy": "cp -r test/data build/test/",
-    "sync": "ts-node sync/sync.ts"
+    "sync": "ts-node sync/sync.ts",
+    "clean": "rimraf build"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
No more failing tests because you have build artifacts from another branch! Clean the build folder before running tests.

Change-type: patch
Signed-off-by: Miguel Casqueira <miguel@balena.io>