### PR TITLE
Add tilde as a shortcut for project root, allowing shorter imports.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,11 @@
 		"skipLibCheck": true,
 		"lib": ["es6"],
 		"resolveJsonModule": true,
-		"allowJs": true
+		"allowJs": true,
+		"baseUrl": "./",
+		"paths": {
+			"~/*": [ "*" ]
+		}
 	},
 	"include": ["src/**/*", "test/**/*", "typings/**/*.d.ts"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,11 @@
 {
-	"extends": ["@balena/lint/config/tslint-prettier.json"]
+	"extends": ["@balena/lint/config/tslint-prettier.json"],
+	"settings": {
+		"import/resolver": {
+			"alias": {
+				"map": [["~", "./"]],
+				"extensions": [".ts", ".js", ".tsx"]
+			}
+		}
+	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,6 +81,7 @@ module.exports = function (env) {
 			alias: {
 				// Use the es2018 build instead of the default es2015 build
 				'pinejs-client-core': 'pinejs-client-core/es2018',
+				'~': path.resolve(__dirname, './'),
 			},
 		},
 		target: 'node',


### PR DESCRIPTION
Imports may be made with file paths like so: `~/src/lib/constants.ts`, where `~` is the project root.

Change-type: patch
Signed-off-by: Christina Wang <christina@balena.io>