### PR TITLE
Remove version tag from livepush generated image

### DIFF
--- a/sync/init.ts
+++ b/sync/init.ts
@@ -16,7 +16,7 @@ interface Opts {
 
 export async function initDevice(opts: Opts) {
 	const arch = opts.arch ?? (await device.getDeviceArch(opts.docker));
-	const image = `${opts.imageName}:${opts.imageTag}`;
+	const image = `${opts.imageName}-${opts.imageTag}`;
 
 	await device.performBuild(opts.docker, opts.dockerfile, {
 		buildargs: { ARCH: arch },
@@ -31,11 +31,7 @@ export async function initDevice(opts: Opts) {
 	// /tmp/update-supervisor.conf with our version, and
 	// restart the supervisor
 	await device.stopSupervisor(opts.address);
-	await device.replaceSupervisorImage(
-		opts.address,
-		opts.imageName,
-		opts.imageTag,
-	);
+	await device.replaceSupervisorImage(opts.address, image, 'latest');
 	await device.startSupervisor(opts.address);
 
 	let supervisorContainer: undefined | Docker.ContainerInfo;


### PR DESCRIPTION
The `start-resin-supervisor` script in newer OS version no longer uses the
SUPERVISOR_TAG environment variable setup on supervisor.conf and
update-supervisor.conf.

This change removes the need for that variable with livepush supervisor
to make it compatible with older and newer OS versions

Change-type: patch