### PR TITLE
Fix passing driver_opts from compose to docker network creation

### DIFF
--- a/src/compose/network.ts
+++ b/src/compose/network.ts
@@ -130,6 +130,7 @@ export class Network {
 			Name: Network.generateDockerName(this.appId, this.name),
 			Driver: this.config.driver,
 			CheckDuplicate: true,
+			Options: this.config.options,
 			IPAM: {
 				Driver: this.config.ipam.driver,
 				Config: this.config.ipam.config.map((conf) => {


### PR DESCRIPTION
Connects-to: https://github.com/balena-os/balena-supervisor/issues/1689
Change-Type: patch
Signed-off-by: quentinGllmt <quentin@quentingllmt.fr>