### PR TITLE
Patch awaiting response when checking if supervisor0 network exists

### DIFF
--- a/src/compose/network-manager.ts
+++ b/src/compose/network-manager.ts
@@ -70,7 +70,7 @@ export async function remove(network: Network) {
 }
 
 export async function supervisorNetworkReady(): Promise<boolean> {
-	const networkExists = exists(
+	const networkExists = await exists(
 		`/sys/class/net/${constants.supervisorNetworkInterface}`,
 	);
 	if (!networkExists) {


### PR DESCRIPTION
Our changes to move to using standard lib fs functions added a regression where checking if the supervisor0 network exists is not awaited for the response. This fixes that. https://github.com/balena-os/balena-supervisor/commit/4a2ac557ef11d334154bafa0cab4e7272cbed749#diff-bb7547de5afc63925925900846ce189e9b34cc4b8d1916e70928fa44f98a8fd0L73