### PR TITLE
Prevent a recursive loop when reporting current state

### DIFF
--- a/src/device-state/current-state.ts
+++ b/src/device-state/current-state.ts
@@ -203,14 +203,10 @@ const reportCurrentState = (): null => {
 				...currentDeviceState.dependent,
 			};
 
-			const stateDiff = getStateDiff();
-			if (_.size(stateDiff) === 0) {
-				reportPending = false;
-				return null;
-			}
-
+			// Report current state
 			await report();
-			reportCurrentState();
+			// Finishing pending report
+			reportPending = false;
 		} catch (e) {
 			eventTracker.track('Device state report failure', { error: e });
 			// We use the poll interval as the upper limit of
@@ -241,5 +237,6 @@ export const startReporting = () => {
 	// But check once every max report frequency to ensure that changes in system
 	// info are picked up (CPU temp etc)
 	setInterval(doReport, constants.maxReportFrequency);
-	return reportCurrentState();
+	// Try to perform a report right away
+	return doReport();
 };

--- a/test/src/device-state/current-state.spec.ts
+++ b/test/src/device-state/current-state.spec.ts
@@ -505,25 +505,6 @@ describe('device-state/current-state', () => {
 			report.cancel();
 		});
 
-		it('does not report if current state has not changed', async () => {
-			// Use a temporary unhandledRejectionHandler to catch the promise
-			// rejection from the Bluebird.delay stub
-			process.on('unhandledRejection', unhandledRejectionHandler);
-			spy(_, 'size');
-
-			reportCurrentState();
-
-			// Wait 200ms for anonymous async IIFE inside reportCurrentState to finish executing
-			// TODO: is there a better way to test this? Possible race condition
-			await sleep(200);
-
-			expect(stateForReport).to.deep.equal({ local: {}, dependent: {} });
-			expect(_.size as SinonSpy).to.have.returned(0);
-
-			(_.size as SinonSpy).restore();
-			process.removeListener('unhandledRejection', unhandledRejectionHandler);
-		});
-
 		it('sends a null patch for system metrics when HARDWARE_METRICS is false', async () => {
 			// Use a temporary unhandledRejectionHandler to catch the promise
 			// rejection from the Bluebird.delay stub


### PR DESCRIPTION
The code previously calculated the current state until the state it just calculates is the same as the last calculated state. This is an issue with device metrics because a single CPU temp/usage, bit in memory usage, etc would cause a loop making the device calculate the current state over and over until it breaks out. Theoretically it could get stuck into this loop forever. 

After applying this fix I saw that calculating the current state was only performed every 10 seconds which matches the maxReportFrequency is value. There are more optimizations to be done in this module with regards to calculating current state diff because as we increase the size of the current state that function will be performing more and more operations. This is evident in CPU usage as I documented in #1673 which shows CPU spikes growing as the Supervisor continues to be developed. We should optimize the state diff check function next to try and reduce the 10-50% CPU spikes I was seeing even with this change however it was usually a 18% cpu spike every 10 seconds when the current state diff was ran. Only once was it greater then 18% over 5 minutes.

Closes: #1673
Change-type: patch
Signed-off-by: Miguel Casqueira <miguel@balena.io>