### PR TITLE
Refactor debug log when unmanaged volume is found

### DIFF
--- a/src/compose/volume-manager.ts
+++ b/src/compose/volume-manager.ts
@@ -33,7 +33,7 @@ export async function getAll(): Promise<Volume[]> {
 			volumesList.push(volume);
 		} catch (err) {
 			if (err instanceof InternalInconsistencyError) {
-				log.debug(`Cannot parse Volume: ${volumeInfo.Name}`);
+				log.debug(`Found unmanaged Volume: ${volumeInfo.Name}`);
 			} else {
 				throw err;
 			}

--- a/test/44-volume-manager.spec.ts
+++ b/test/44-volume-manager.spec.ts
@@ -71,7 +71,9 @@ describe('Volume Manager', () => {
 				},
 			]);
 			// Check that debug message was logged saying we found a Volume not created by us
-			expect(logDebug.lastCall.lastArg).to.equal('Cannot parse Volume: decoy');
+			expect(logDebug.lastCall.lastArg).to.equal(
+				'Found unmanaged Volume: decoy',
+			);
 		});
 	});
 


### PR DESCRIPTION
This log was added simply just to tell the user that we see an unmanaged volume. It however seemed like there was an issue parsing a volume which required some action to correct. The log is just to convey "we found this".