### PR TITLE
Add revpi-connect, revpi-core-3 to Raspberry Pi variants

### DIFF
--- a/src/config/backends/config-txt.ts
+++ b/src/config/backends/config-txt.ts
@@ -53,9 +53,14 @@ export class ConfigTxt extends ConfigBackend {
 
 	public async matches(deviceType: string): Promise<boolean> {
 		return (
-			['fincm3', 'rt-rpi-300', '243390-rpi3', 'nebra-hnt'].includes(
-				deviceType,
-			) || deviceType.startsWith('raspberry')
+			[
+				'fincm3',
+				'rt-rpi-300',
+				'243390-rpi3',
+				'nebra-hnt',
+				'revpi-connect',
+				'revpi-core-3',
+			].includes(deviceType) || deviceType.startsWith('raspberry')
 		);
 	}
 


### PR DESCRIPTION
We need the supervisor to be able to manage config.txt changes for these
Revolution Pi boards too.

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>