### PR TITLE
Fix supervisor using wrong source for deltas

### DIFF
--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -596,10 +596,13 @@ export function bestDeltaSource(
 				return availableImage.name;
 			}
 		}
-	}
-	for (const availableImage of available) {
-		if (availableImage.appId === image.appId) {
-			return availableImage.name;
+	} else {
+		// This only makes sense for dependent devices which are still
+		// single app.
+		for (const availableImage of available) {
+			if (availableImage.appId === image.appId) {
+				return availableImage.name;
+			}
 		}
 	}
 	return null;


### PR DESCRIPTION
This fixes a specific issue when the supervisor cannot find the right
source for deltas (e.g. after the DB gets deleted), where legacy
behavior was to look for any image in the app.

Change-type: patch
Relates-to: #1729