### PR TITLE
Point users to the configuration page for overriding update locks

### DIFF
--- a/docs/update-locking.md
+++ b/docs/update-locking.md
@@ -86,6 +86,9 @@ The update lock can be overridden in case you need to force an update, for insta
 
 To do this the device or fleet must have `BALENA_SUPERVISOR_OVERRIDE_LOCK` configuration variable set to "1".
 
-The easiest way to do this is to toggle the override in the actions section of your device. Go to the device you'd like to override a lock, then click the actions menu on the left hand side, and locate the 'Update lock override' toggle. Be sure to remove this toggle after if you'd like your update locks to work.
+The easiest way to do this is to use the 'Override the update lock ...' toggle in the [Fleet or Device Configuration][device-configuration] page. Go to the configuration page of the device or fleet, locate the 'Override the update lock ...' item, click the activate button, and set the toggle to enabled. Disable the toggle afterwards in order to restore the update locks.
 
 Also, you can programatically do this by hitting the `/v1/update` endpoint of the [supervisor HTTP API](./API.md), with `{ "force": true }` as body.
+
+
+[device-configuration]:/learn/manage/configuration/#managing-device-configuration-variables


### PR DESCRIPTION
Change-type: patch
See: https://jel.ly.fish/32cc2ee4-c5a7-4ec8-8e91-1ba4f1379bc4
See: https://www.flowdock.com/app/rulemotion/r-product/threads/9mk8QcdNp4UAwKeEUpXPHVxYM_c
See: https://github.com/balena-io/docs/pull/1929
Signed-off-by: Thodoris Greasidis thodoris@balena.io