### PR TITLE
Remove comparisons based on image, release, and service ids

### DIFF
--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -125,7 +125,6 @@ let targetVolatilePerImageId: {
 export const initialized = (async () => {
 	await config.initialized;
 
-	await imageManager.initialized;
 	await imageManager.cleanImageData();
 	const cleanup = async () => {
 		const containers = await docker.listContainers({ all: true });

--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -179,7 +179,7 @@ export async function getRequiredSteps(
 ): Promise<CompositionStep[]> {
 	// get some required data
 	const [downloading, availableImages, currentApps] = await Promise.all([
-		imageManager.getDownloadingImageIds(),
+		imageManager.getDownloadingImageNames(),
 		imageManager.getAvailable(),
 		getCurrentApps(),
 	]);
@@ -199,7 +199,7 @@ export async function inferNextSteps(
 	targetApps: InstancedAppState,
 	{
 		ignoreImages = false,
-		downloading = [] as number[],
+		downloading = [] as string[],
 		availableImages = [] as Image[],
 		containerIdsByAppId = {} as { [appId: number]: Dictionary<string> },
 	} = {},
@@ -674,7 +674,7 @@ function saveAndRemoveImages(
 			(svc) =>
 				_.find(availableImages, {
 					dockerImageId: svc.config.image,
-					imageId: svc.imageId,
+					name: svc.imageName,
 				}) ?? _.find(availableImages, { dockerImageId: svc.config.image }),
 		),
 	) as imageManager.Image[];

--- a/src/compose/images.ts
+++ b/src/compose/images.ts
@@ -121,30 +121,30 @@ function createTask(initialContext: Image) {
 	return running(initialContext);
 }
 
-const runningTasks: { [imageId: number]: ImageTask } = {};
+const runningTasks: { [imageName: string]: ImageTask } = {};
 function reportEvent(event: 'start' | 'update' | 'finish', state: Image) {
-	const { imageId } = state;
+	const { name: imageName } = state;
 
 	// Emit by default if a start event is reported
 	let emitChange = event === 'start';
 
 	// Get the current task and update it in memory
 	const currentTask =
-		event === 'start' ? createTask(state) : runningTasks[imageId];
-	runningTasks[imageId] = currentTask;
+		event === 'start' ? createTask(state) : runningTasks[imageName];
+	runningTasks[imageName] = currentTask;
 
 	// TODO: should we assert that the current task exists at this point?
 	// On update, update the corresponding task with the new state if it exists
 	if (event === 'update' && currentTask) {
 		const [updatedTask, changed] = currentTask.update(state);
-		runningTasks[imageId] = updatedTask;
+		runningTasks[imageName] = updatedTask;
 		emitChange = changed;
 	}
 
 	// On update, update the corresponding task with the new state if it exists
 	if (event === 'finish' && currentTask) {
 		[, emitChange] = currentTask.finish();
-		delete runningTasks[imageId];
+		delete runningTasks[imageName];
 	}
 
 	if (emitChange) {
@@ -352,6 +352,12 @@ export function getDownloadingImageIds(): number[] {
 	return Object.values(runningTasks)
 		.filter((t) => t.context.status === 'Downloading')
 		.map((t) => t.context.imageId);
+}
+
+export function getDownloadingImageNames(): string[] {
+	return Object.values(runningTasks)
+		.filter((t) => t.context.status === 'Downloading')
+		.map((t) => t.context.name);
 }
 
 export async function cleanImageData(): Promise<void> {

--- a/src/compose/images.ts
+++ b/src/compose/images.ts
@@ -15,7 +15,6 @@ import {
 	StatusError,
 } from '../lib/errors';
 import * as LogTypes from '../lib/log-types';
-import * as validation from '../lib/validation';
 import * as logger from '../logger';
 import { ImageDownloadBackoffError } from './errors';
 
@@ -68,8 +67,90 @@ const imageFetchLastFailureTime: Dictionary<ReturnType<
 	typeof process.hrtime
 >> = {};
 const imageCleanupFailures: Dictionary<number> = {};
-// A store of volatile state for images (e.g. download progress), indexed by imageId
-const volatileState: { [imageId: number]: Image } = {};
+
+type ImageState = Pick<Image, 'status' | 'downloadProgress'>;
+type ImageTask = {
+	// Indicates whether the task has been finished
+	done?: boolean;
+
+	// Current image state of the task
+	context: Image;
+
+	// Update the task with new context. This is a pure function
+	// meaning it doesn't modify the original task
+	update: (change?: ImageState) => ImageTaskUpdate;
+
+	// Finish the task. This is a pure function
+	// meaning it doesn't modify the original task
+	finish: () => ImageTaskUpdate;
+};
+
+type ImageTaskUpdate = [ImageTask, boolean];
+
+// Create new running task with the given initial context
+function createTask(initialContext: Image) {
+	// Task has only two state, is either running or finished
+	const running = (context: Image): ImageTask => {
+		return {
+			context,
+			update: ({ status, downloadProgress }: ImageState) =>
+				// Keep current state
+				[
+					running({
+						...context,
+						...(status && { status }),
+						...(downloadProgress && { downloadProgress }),
+					}),
+					// Only mark the task as changed if there is new data
+					[status, downloadProgress].some((v) => !!v),
+				],
+			finish: () => [finished(context), true],
+		};
+	};
+
+	// Once the task is finished, it cannot go back to a running state
+	const finished = (context: Image): ImageTask => {
+		return {
+			done: true,
+			context,
+			update: () => [finished(context), false],
+			finish: () => [finished(context), false],
+		};
+	};
+
+	return running(initialContext);
+}
+
+const runningTasks: { [imageId: number]: ImageTask } = {};
+function reportEvent(event: 'start' | 'update' | 'finish', state: Image) {
+	const { imageId } = state;
+
+	// Emit by default if a start event is reported
+	let emitChange = event === 'start';
+
+	// Get the current task and update it in memory
+	const currentTask =
+		event === 'start' ? createTask(state) : runningTasks[imageId];
+	runningTasks[imageId] = currentTask;
+
+	// TODO: should we assert that the current task exists at this point?
+	// On update, update the corresponding task with the new state if it exists
+	if (event === 'update' && currentTask) {
+		const [updatedTask, changed] = currentTask.update(state);
+		runningTasks[imageId] = updatedTask;
+		emitChange = changed;
+	}
+
+	// On update, update the corresponding task with the new state if it exists
+	if (event === 'finish' && currentTask) {
+		[, emitChange] = currentTask.finish();
+		delete runningTasks[imageId];
+	}
+
+	if (emitChange) {
+		events.emit('change');
+	}
+}
 
 let appUpdatePollInterval: number;
 
@@ -125,12 +206,7 @@ export async function triggerFetch(
 	}
 
 	const onProgress = (progress: FetchProgressEvent) => {
-		// Only report the percentage if we haven't finished fetching
-		if (volatileState[image.imageId] != null) {
-			reportChange(image.imageId, {
-				downloadProgress: progress.percentage,
-			});
-		}
+		reportEvent('update', { ...image, downloadProgress: progress.percentage });
 	};
 
 	let success: boolean;
@@ -157,10 +233,13 @@ export async function triggerFetch(
 			}
 			throw e;
 		}
-		reportChange(
-			image.imageId,
-			_.merge(_.clone(image), { status: 'Downloading', downloadProgress: 0 }),
-		);
+
+		// Report a fetch start
+		reportEvent('start', {
+			...image,
+			status: 'Downloading',
+			downloadProgress: 0,
+		});
 
 		try {
 			let id;
@@ -197,7 +276,7 @@ export async function triggerFetch(
 		}
 	}
 
-	reportChange(image.imageId);
+	reportEvent('finish', image);
 	onFinish(success);
 }
 
@@ -280,9 +359,9 @@ export async function getAvailable(): Promise<Image[]> {
 }
 
 export function getDownloadingImageIds(): number[] {
-	return _.keys(_.pickBy(volatileState, { status: 'Downloading' })).map((i) =>
-		validation.checkInt(i),
-	) as number[];
+	return Object.values(runningTasks)
+		.filter((t) => t.context.status === 'Downloading')
+		.map((t) => t.context.imageId);
 }
 
 export async function cleanImageData(): Promise<void> {
@@ -331,18 +410,22 @@ export async function cleanImageData(): Promise<void> {
 }
 
 export const getStatus = async () => {
-	const images = await getAvailable();
-	for (const image of images) {
-		image.status = 'Downloaded';
-		image.downloadProgress = null;
-	}
-	const status = _.clone(volatileState);
-	for (const image of images) {
-		if (status[image.imageId] == null) {
-			status[image.imageId] = image;
-		}
-	}
-	return _.values(status);
+	const images = (await getAvailable()).map((img) => ({
+		...img,
+		status: 'Downloaded' as Image['status'],
+		downloadImageSuccess: null,
+	}));
+
+	const imagesFromRunningTasks = Object.values(runningTasks).map(
+		(task) => task.context,
+	);
+	const runningImageIds = imagesFromRunningTasks.map((img) => img.imageId);
+
+	// TODO: this is possibly wrong, the value from getAvailable should be more reliable
+	// than the value from running tasks
+	return imagesFromRunningTasks.concat(
+		images.filter((img) => !runningImageIds.includes(img.imageId)),
+	);
 };
 
 export async function update(image: Image): Promise<void> {
@@ -593,10 +676,7 @@ async function removeImageIfNotNeeded(image: Image): Promise<void> {
 			[] as string[],
 		);
 
-		reportChange(
-			image.imageId,
-			_.merge(_.clone(image), { status: 'Deleting' }),
-		);
+		reportEvent('start', { ...image, status: 'Deleting' });
 		logger.logSystemEvent(LogTypes.deleteImage, { image });
 
 		// The engine doesn't handle concurrency too well. If two requests to
@@ -641,7 +721,7 @@ async function removeImageIfNotNeeded(image: Image): Promise<void> {
 			throw e;
 		}
 	} finally {
-		reportChange(image.imageId);
+		reportEvent('finish', image);
 	}
 
 	await db.models('image').del().where({ id: img.id });
@@ -705,21 +785,4 @@ function fetchImage(
 ): Promise<string> {
 	logger.logSystemEvent(LogTypes.downloadImage, { image });
 	return dockerUtils.fetchImageWithProgress(image.name, opts, onProgress);
-}
-
-// TODO: find out if imageId can actually be null
-function reportChange(imageId: Nullable<number>, status?: Partial<Image>) {
-	if (imageId == null) {
-		return;
-	}
-	if (status != null) {
-		if (volatileState[imageId] == null) {
-			volatileState[imageId] = { imageId } as Image;
-		}
-		_.merge(volatileState[imageId], status);
-		return events.emit('change');
-	} else if (volatileState[imageId] != null) {
-		delete volatileState[imageId];
-		return events.emit('change');
-	}
 }

--- a/src/compose/images.ts
+++ b/src/compose/images.ts
@@ -152,18 +152,6 @@ function reportEvent(event: 'start' | 'update' | 'finish', state: Image) {
 	}
 }
 
-let appUpdatePollInterval: number;
-
-export const initialized = (async () => {
-	await config.initialized;
-	appUpdatePollInterval = await config.get('appUpdatePollInterval');
-	config.on('change', (vals) => {
-		if (vals.appUpdatePollInterval != null) {
-			appUpdatePollInterval = vals.appUpdatePollInterval;
-		}
-	});
-})();
-
 type ServiceInfo = Pick<
 	Service,
 	'imageName' | 'appId' | 'serviceId' | 'serviceName' | 'imageId' | 'releaseId'
@@ -187,6 +175,8 @@ export async function triggerFetch(
 	onFinish = _.noop,
 	serviceName: string,
 ): Promise<void> {
+	const appUpdatePollInterval = await config.get('appUpdatePollInterval');
+
 	if (imageFetchFailures[image.name] != null) {
 		// If we are retrying a pull within the backoff time of the last failure,
 		// we need to throw an error, which will be caught in the device-state

--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -373,7 +373,7 @@ export async function addFeaturesFromLabels(
 			// create a app/service specific API secret
 			const apiSecret = await apiKeys.generateScopedKey(
 				service.appId,
-				service.serviceId,
+				service.serviceName,
 			);
 
 			const host = (() => {

--- a/src/device-api/common.js
+++ b/src/device-api/common.js
@@ -121,13 +121,6 @@ export async function doPurge(appId, force) {
 		});
 }
 
-export function serviceAction(action, serviceId, current, target, options) {
-	if (options == null) {
-		options = {};
-	}
-	return { action, serviceId, current, target, options };
-}
-
 /**
  * This doesn't truly return an InstancedDeviceState, but it's close enough to mostly work where it's used
  *

--- a/src/migrations/M00007.js
+++ b/src/migrations/M00007.js
@@ -1,0 +1,41 @@
+export async function up(knex) {
+	// Add serviceName to apiSecret schema
+	await knex.schema.table('apiSecret', (table) => {
+		table.string('serviceName');
+		table.unique(['appId', 'serviceName']);
+	});
+
+	const targetServices = (await knex('app').select(['appId', 'services']))
+		.map(({ appId, services }) => ({
+			appId,
+			// Extract service name and id per app
+			services: JSON.parse(services).map(({ serviceId, serviceName }) => ({
+				serviceId,
+				serviceName,
+			})),
+		}))
+		.reduce(
+			// Convert to array of {appId, serviceId, serviceName}
+			(apps, { appId, services }) =>
+				apps.concat(services.map((svc) => ({ appId, ...svc }))),
+			[],
+		);
+
+	// Update all API secret entries so services can still access the API after
+	// the change
+	await Promise.all(
+		targetServices.map(({ appId, serviceId, serviceName }) =>
+			knex('apiSecret').update({ serviceName }).where({ appId, serviceId }),
+		),
+	);
+
+	// Update the table schema deleting the serviceId column
+	await knex.schema.table('apiSecret', (table) => {
+		table.dropUnique(['appId', 'serviceId']);
+		table.dropColumn('serviceId');
+	});
+}
+
+export function down() {
+	return Promise.reject(new Error('Not Implemented'));
+}

--- a/test/21-supervisor-api.spec.ts
+++ b/test/21-supervisor-api.spec.ts
@@ -64,7 +64,7 @@ describe('SupervisorAPI', () => {
 	describe('API Key Scope', () => {
 		it('should generate a key which is scoped for a single application', async () => {
 			// single app scoped key...
-			const appScopedKey = await apiKeys.generateScopedKey(1, 1);
+			const appScopedKey = await apiKeys.generateScopedKey(1, 'main');
 
 			await request
 				.get('/v2/applications/1/state')
@@ -74,7 +74,7 @@ describe('SupervisorAPI', () => {
 		});
 		it('should generate a key which is scoped for multiple applications', async () => {
 			// multi-app scoped key...
-			const multiAppScopedKey = await apiKeys.generateScopedKey(1, 2, {
+			const multiAppScopedKey = await apiKeys.generateScopedKey(1, 'other', {
 				scopes: [1, 2].map((appId) => {
 					return { type: 'app', appId };
 				}),
@@ -135,7 +135,7 @@ describe('SupervisorAPI', () => {
 		});
 		it('should regenerate a key and invalidate the old one', async () => {
 			// single app scoped key...
-			const appScopedKey = await apiKeys.generateScopedKey(1, 1);
+			const appScopedKey = await apiKeys.generateScopedKey(1, 'main');
 
 			await request
 				.get('/v2/applications/1/state')

--- a/test/28-db-format.spec.ts
+++ b/test/28-db-format.spec.ts
@@ -86,7 +86,6 @@ describe('DB Format', () => {
 		expect(app).to.be.an.instanceOf(App);
 		expect(app).to.have.property('appId').that.equals(1);
 		expect(app).to.have.property('commit').that.equals('abcdef');
-		expect(app).to.have.property('releaseId').that.equals(123);
 		expect(app).to.have.property('appName').that.equals('test-app');
 		expect(app)
 			.to.have.property('source')

--- a/test/41-device-api-v1.spec.ts
+++ b/test/41-device-api-v1.spec.ts
@@ -1232,7 +1232,7 @@ describe('SupervisorAPI [V1 Endpoints]', () => {
 			// resolve to true for any isScoped check
 			const scopedKey = await apiKeys.generateScopedKey(
 				2,
-				containers[0].serviceId,
+				containers[0].serviceName,
 			);
 
 			await request

--- a/test/42-device-api-v2.spec.ts
+++ b/test/42-device-api-v2.spec.ts
@@ -142,7 +142,7 @@ describe('SupervisorAPI [V2 Endpoints]', () => {
 
 		describe('Scoped API Keys', () => {
 			it('returns 409 because app is out of scope of the key', async () => {
-				const apiKey = await apiKeys.generateScopedKey(3, 1);
+				const apiKey = await apiKeys.generateScopedKey(3, 'main');
 				await request
 					.get('/v2/applications/2/state')
 					.set('Accept', 'application/json')
@@ -164,7 +164,7 @@ describe('SupervisorAPI [V2 Endpoints]', () => {
 
 		it('should return scoped application', async () => {
 			// Create scoped key for application
-			const appScopedKey = await apiKeys.generateScopedKey(1658654, 640681);
+			const appScopedKey = await apiKeys.generateScopedKey(1658654, 'main');
 			// Setup device conditions
 			serviceManagerMock.resolves([mockedAPI.mockService({ appId: 1658654 })]);
 			imagesMock.resolves([mockedAPI.mockImage({ appId: 1658654 })]);
@@ -188,7 +188,7 @@ describe('SupervisorAPI [V2 Endpoints]', () => {
 
 		it('should return no application info due to lack of scope', async () => {
 			// Create scoped key for wrong application
-			const appScopedKey = await apiKeys.generateScopedKey(1, 1);
+			const appScopedKey = await apiKeys.generateScopedKey(1, 'main');
 			// Setup device conditions
 			serviceManagerMock.resolves([mockedAPI.mockService({ appId: 1658654 })]);
 			imagesMock.resolves([mockedAPI.mockImage({ appId: 1658654 })]);
@@ -211,7 +211,7 @@ describe('SupervisorAPI [V2 Endpoints]', () => {
 
 		it('should return success when device has no applications', async () => {
 			// Create scoped key for any application
-			const appScopedKey = await apiKeys.generateScopedKey(1658654, 1658654);
+			const appScopedKey = await apiKeys.generateScopedKey(1658654, 'main');
 			// Setup device conditions
 			serviceManagerMock.resolves([]);
 			imagesMock.resolves([]);
@@ -234,7 +234,7 @@ describe('SupervisorAPI [V2 Endpoints]', () => {
 
 		it('should only return 1 application when N > 1 applications on device', async () => {
 			// Create scoped key for application
-			const appScopedKey = await apiKeys.generateScopedKey(1658654, 640681);
+			const appScopedKey = await apiKeys.generateScopedKey(1658654, 'main');
 			// Setup device conditions
 			serviceManagerMock.resolves([
 				mockedAPI.mockService({ appId: 1658654 }),
@@ -330,7 +330,7 @@ describe('SupervisorAPI [V2 Endpoints]', () => {
 
 		before(async () => {
 			// Create scoped key for application
-			appScopedKey = await apiKeys.generateScopedKey(1658654, 640681);
+			appScopedKey = await apiKeys.generateScopedKey(1658654, 'main');
 
 			// Mock target state cache
 			targetStateCacheMock = stub(targetStateCache, 'getTargetApp');
@@ -439,7 +439,7 @@ describe('SupervisorAPI [V2 Endpoints]', () => {
 
 		before(async () => {
 			// Create scoped key for application
-			appScopedKey = await apiKeys.generateScopedKey(1658654, 640681);
+			appScopedKey = await apiKeys.generateScopedKey(1658654, 'main');
 
 			// Mock target state cache
 			targetStateCacheMock = stub(targetStateCache, 'getTargetApp');


### PR DESCRIPTION
Preparing for the new v3 target state, where the supervisor will make environment
dependent ids optional and rely on using general UUIDs and user known identifiers
for comparison. This PR moves forward in that direction by removing some of those
comparisons for v2 target state.

- `imageId` to be replaced with `imageName`
- `serviceId` to be replace by `serviceName`
- `releaseId` to be replaced by `commit` (future `releaseUuid`)

This is a backwards compatible change, meaning it doesn't completely get rid of
these identifiers (which are still being used by supervisor API and for state
patch), but will not depend on those identifiers for calculating steps to target state.

One important change, although one that should not affect running applications is that this PR renames
service containers from `<serviceName>_<serviceId>_<releaseId>` to `<serviceName>_<serviceId>_<releaseId>_<commit>`

Once we can phase supervisor API v1 and v2 endpoints and replace them by a feature complete v3 API, then we'll be able to rename the containers to `<serviceName>_<commit>`


Change-type: minor