### PR TITLE
Force remove container on Docker daemon 409

### DIFF
--- a/src/compose/service-manager.ts
+++ b/src/compose/service-manager.ts
@@ -555,6 +555,11 @@ function killContainer(
 					logger.logSystemEvent(LogTypes.stopRemoveServiceNoop, {
 						service,
 					});
+				} else if (statusCode === 409 && removeContainer) {
+					// 409 means the container is refusing to be stopped, however this will lead to a service
+					// stop error loop. If the container needs to be removed anyway, we force-remove the container.
+					logger.logSystemEvent(LogTypes.stopRemoveServiceNoop, { service });
+					return containerObj.remove({ v: true, force: true });
 				} else {
 					throw e;
 				}


### PR DESCRIPTION
If removeContainer is true, force the removal. However,
this doesn't cover a 409 case when removeContainer is false.

Change-type: patch
Relates-to: #1754
Signed-off-by: Christina Wang <christina@balena.io>