### PR TITLE
Replace OS variant with development mode

### DIFF
--- a/src/config/schema-type.ts
+++ b/src/config/schema-type.ts
@@ -170,6 +170,10 @@ export const schemaTypes = {
 		type: PermissiveBoolean,
 		default: true,
 	},
+	developmentMode: {
+		type: PermissiveBoolean,
+		default: false,
+	},
 
 	// Function schema types
 	// The type should be the value that the promise resolves

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -79,6 +79,11 @@ export const schema = {
 		mutable: false,
 		removeIfNull: false,
 	},
+	developmentMode: {
+		source: 'config.json',
+		mutable: true,
+		removeIfNull: false,
+	},
 
 	name: {
 		source: 'db',

--- a/src/lib/api-keys.ts
+++ b/src/lib/api-keys.ts
@@ -125,12 +125,10 @@ export const authMiddleware: AuthorizedRequestHandler = async (
 	};
 
 	try {
-		const conf = await config.getMany(['localMode', 'unmanaged', 'osVariant']);
+		const conf = await config.getMany(['localMode', 'unmanaged']);
 
-		// we only need to check the API key if a) unmanaged and on a production image, or b) managed and not in local mode
-		const needsAuth = conf.unmanaged
-			? conf.osVariant === 'prod'
-			: !conf.localMode;
+		// we only need to check the API key if managed and not in local mode
+		const needsAuth = !conf.unmanaged && !conf.localMode;
 
 		// no need to authenticate, shortcut
 		if (!needsAuth) {

--- a/test/03-config.spec.ts
+++ b/test/03-config.spec.ts
@@ -99,13 +99,13 @@ describe('Config', () => {
 		conf.set({ name: 'someValue' });
 	});
 
-	it("returns an undefined OS variant if it doesn't exist", async () => {
+	it("returns production OS variant if it doesn't exist", async () => {
 		const oldPath = constants.hostOSVersionPath;
 		constants.hostOSVersionPath = 'test/data/etc/os-release-novariant';
 
 		const osVariant = await conf.get('osVariant');
 		constants.hostOSVersionPath = oldPath;
-		expect(osVariant).to.be.undefined;
+		expect(osVariant).to.equal('prod');
 	});
 
 	it('reads and exposes MAC addresses', async () => {


### PR DESCRIPTION
* Replaces checking variant in `/etc/os-releases` with a `config.json` check for `developmentMode`
* Using API keys do not check for OS variant