### PR TITLE
Created new dind tool, works with latest supervisor.

### DIFF
--- a/tools/dind/dind2
+++ b/tools/dind/dind2
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+#
+# This tool can be used to facilitate supervisor development. This tools runs a supervisor
+# on a Docker instance of a Balena OS. It can be used the the live-push feature in the
+# supervisors code base.
+#
+# Usage: dind2 action [options]
+#
+# Actions:
+#   start [options]           Start docker in docker.
+#   stop                      Stop the docker in docker instance.
+#   logs [-f]                 Prints our supervisor logs. Use -f to follow or any other arguments you'd wish to send to journalctl.
+#
+# Options:
+#   --os-version              Specify the balena-os version to use. See note 1. Default: 2.58.6_rev1
+#   --device-type             Specify the device type. See note 1. Default: genericx86-64-ext
+#
+#
+# Notes:
+#   1: Will be used as so: resin/resinos:${OS_VERSION}.dev-${DEVICE_TYPE}
+#
+
+THIS_FILE=$0
+OS_VERSION="2.58.6_rev1"
+DEVICE_TYPE="genericx86-64-ext"
+DIND_PREFIX="balenaos-in-container"
+DIND_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+function parseOptions {
+  while [[ $# -ge 1 ]]; do
+    case $1 in
+    --os-version)
+      OS_VERSION="$2"
+      shift || { echo "--os-version not specified" && exit 1; }
+      ;;
+    --device-type)
+      DEVICE_TYPE="$2"
+      shift || { echo "--device-type not specified" && exit 1; }
+      ;;
+    *)
+      echo "Warning: unknown argument: $1" && exit 1
+      ;;
+    esac
+    shift
+  done
+}
+
+function startDind {
+  stopDind
+
+  #get balenaos-in-container submodule if not present.
+  if [ ! -f "${DIND_DIR}/balenaos-in-container/docker-compose-yml" ]; then
+    cd "${DIND_DIR}/../.." && git submodule update --init
+  fi
+
+  #check if config.json exists.
+  if [ ! -f "$DIND_DIR/config.json" ]; then
+    echo "Config.json is missing."
+    exit 1
+  fi
+
+  #run balenaos in docker.
+  echo "Starting dind."
+  cp $DIND_DIR/config.json $DIND_DIR/balenaos-in-container/config.json
+  cd $DIND_DIR/balenaos-in-container &&
+    OS_VERSION=$OS_VERSION DEVICE_TYPE=$DEVICE_TYPE docker-compose build --no-cache &&
+    OS_VERSION=$OS_VERSION DEVICE_TYPE=$DEVICE_TYPE docker-compose up --detach
+}
+
+function stopDind {
+  echo "Stopping dind."
+  docker stop ${DIND_PREFIX}_os_1 >/dev/null 2>&1 || true
+  docker rm ${DIND_PREFIX}_os_1 >/dev/null 2>&1 || true
+  docker volume rm ${DIND_PREFIX}_boot >/dev/null 2>&1 || true
+  docker volume rm ${DIND_PREFIX}_data >/dev/null 2>&1 || true
+  docker volume rm ${DIND_PREFIX}_state >/dev/null 2>&1 || true
+}
+
+function logs {
+  docker exec -ti ${DIND_PREFIX}_os_1 journalctl $@
+}
+
+action="$1"
+shift || true
+
+if [ "$action" == "logs" ]; then
+  logs $@
+else
+  parseOptions "$@"
+  case $action in
+  start)
+    startDind
+    ;;
+  stop)
+    stopDind
+    ;;
+  *)
+    echo "Invalid command."
+    ;;
+  esac
+fi


### PR DESCRIPTION
Change-type: minor

I've re-written the dind tool to fix a number of issues and in hopes to remove unmaintained/broken and "no-longer-useful" code.

**What's wrong with dindctl?**
1) The big issue with dindctl is that trying to run versions of the supervisor that uses `device-type.json` (so any of the newer versions) will not work because dindctl uses an outdated `balenaos-in-container` submodule which doesn't cp the `device-type.json` into the boot directory for the supervisor container. The latest version of `balenaos-in-container` does. 
2) Dindctl contains code for its own version of 'live-push' through the use of dindctl refresh. I believe it would be better if the project just keeps to a single live-push feature (the node one; which seems much more maintained). Both dindctl and dind2 works with node live-push, but again, there isn't much use of live-push for dindctl due to bullet number 1. 
3) Dindctl also just seems unmaintained, and filled with a bunch of small bugs. After some time, I just gave up trying to hack things together and decided to attempt this re-write. 

**Dind2** 
Dind2 is simple to use and works with the latest supervisors and balenaos-es.
```
dind2 start \
    --os-version ${balena_os_version} \
    --device-type ${balena_device_type}
```
```
dind2 stop 
```

Then, you just run `npm sync ${docker_container_ip}` and you're good to go. 

**Notes** 
Dindctl has a --preload flag which I haven't tried, and haven't re-implemented in dind2. 

I haven't removed dindctl from this PR yet, but it should be removed if dind2 is to be pulled in. This projects README would also need to be updated. 