### PR TITLE
Skip restarting services if they are part of conf targets

### DIFF
--- a/src/lib/dbus.ts
+++ b/src/lib/dbus.ts
@@ -37,6 +37,7 @@ export async function getLoginManagerInterface() {
 
 async function startUnit(unitName: string) {
 	const systemd = await getSystemdInterface();
+	log.debug(`Starting systemd unit: ${unitName}`);
 	try {
 		systemd.StartUnit(unitName, 'fail');
 	} catch (e) {
@@ -46,6 +47,7 @@ async function startUnit(unitName: string) {
 
 export async function restartService(serviceName: string) {
 	const systemd = await getSystemdInterface();
+	log.debug(`Restarting systemd service: ${serviceName}`);
 	try {
 		systemd.RestartUnit(`${serviceName}.service`, 'fail');
 	} catch (e) {
@@ -63,6 +65,7 @@ export async function startSocket(socketName: string) {
 
 async function stopUnit(unitName: string) {
 	const systemd = await getSystemdInterface();
+	log.debug(`Stopping systemd unit: ${unitName}`);
 	try {
 		systemd.StopUnit(unitName, 'fail');
 	} catch (e) {
@@ -116,7 +119,10 @@ export const shutdown = async () =>
 		}
 	}, 1000);
 
-async function getUnitProperty(unitName: string, property: string) {
+async function getUnitProperty(
+	unitName: string,
+	property: string,
+): Promise<string> {
 	const systemd = await getSystemdInterface();
 	return new Promise((resolve, reject) => {
 		systemd.GetUnit(unitName, async (err: Error, unitPath: string) => {
@@ -132,7 +138,7 @@ async function getUnitProperty(unitName: string, property: string) {
 			iface.Get(
 				'org.freedesktop.systemd1.Unit',
 				property,
-				(e: Error, value: unknown) => {
+				(e: Error, value: string) => {
 					if (e) {
 						return reject(new DbusError(e));
 					}
@@ -145,4 +151,8 @@ async function getUnitProperty(unitName: string, property: string) {
 
 export function serviceActiveState(serviceName: string) {
 	return getUnitProperty(`${serviceName}.service`, 'ActiveState');
+}
+
+export function servicePartOf(serviceName: string) {
+	return getUnitProperty(`${serviceName}.service`, 'PartOf');
 }


### PR DESCRIPTION
Some recent changes to the OS allowed some services to restart
automatically when the associated config files are changed.

In these cases we want to avoid restarting the same services
manually from the supervisor.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-os/balena-supervisor/issues/1775

Tested with 3 manually edited versions of the OS:
1. `balena-hostname` and `balena-proxy-config` both restarted automatically via the hostOS => supervisor does not restart
2. `balena-hostname` and `balena-proxy-config` not restarted automatically via the hostOS => supervisor restarts services
3. `resin-hostname` and `resin-proxy-config` not restarted automatically via the hostOS => supervisor restarts services