### PR TITLE
Use mount instead of binds to bind mount paths into the container

### DIFF
--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -135,6 +135,7 @@ export const initialized = (async () => {
 	await cleanup();
 
 	await localModeManager.init();
+	await serviceManager.createBindDirs();
 	await serviceManager.attachToRunning();
 	serviceManager.listenToEvents();
 

--- a/test/data/docker-states/entrypoint/inspect.json
+++ b/test/data/docker-states/entrypoint/inspect.json
@@ -33,9 +33,20 @@
 	"AppArmorProfile": "",
 	"ExecIDs": null,
 	"HostConfig": {
-		"Binds": [
-			"/tmp/balena-supervisor/services/1011165/main:/tmp/resin",
-			"/tmp/balena-supervisor/services/1011165/main:/tmp/balena"
+		"Binds": null,
+		"Mounts": [
+			{
+				"Type": "bind",
+				"Source": "/tmp/balena-supervisor/services/1011165/main",
+				"Target": "/tmp/resin",
+				"ReadOnly": false
+			},
+			{
+				"Type": "bind",
+				"Source": "/tmp/balena-supervisor/services/1011165/main",
+				"Target": "/tmp/balena",
+				"ReadOnly": false
+			}
 		],
 		"ContainerIDFile": "",
 		"LogConfig": {

--- a/test/data/docker-states/network-mode-service/inspect.json
+++ b/test/data/docker-states/network-mode-service/inspect.json
@@ -34,9 +34,20 @@
 	"AppArmorProfile": "",
 	"ExecIDs": null,
 	"HostConfig": {
-		"Binds": [
-			"/tmp/balena-supervisor/services/1011165/main:/tmp/resin",
-			"/tmp/balena-supervisor/services/1011165/main:/tmp/balena"
+		"Binds": null,
+		"Mounts": [
+			{
+				"Type": "bind",
+				"Source": "/tmp/balena-supervisor/services/1011165/main",
+				"Target": "/tmp/resin",
+				"ReadOnly": false
+			},
+			{
+				"Type": "bind",
+				"Source": "/tmp/balena-supervisor/services/1011165/main",
+				"Target": "/tmp/balena",
+				"ReadOnly": false
+			}
 		],
 		"ContainerIDFile": "",
 		"LogConfig": {

--- a/test/data/docker-states/simple/inspect.json
+++ b/test/data/docker-states/simple/inspect.json
@@ -34,9 +34,20 @@
 	"AppArmorProfile": "",
 	"ExecIDs": null,
 	"HostConfig": {
-		"Binds": [
-			"/tmp/balena-supervisor/services/1011165/main:/tmp/resin",
-			"/tmp/balena-supervisor/services/1011165/main:/tmp/balena"
+		"Binds": null,
+		"Mounts": [
+			{
+				"Type": "bind",
+				"Source": "/tmp/balena-supervisor/services/1011165/main",
+				"Target": "/tmp/resin",
+				"ReadOnly": false
+			},
+			{
+				"Type": "bind",
+				"Source": "/tmp/balena-supervisor/services/1011165/main",
+				"Target": "/tmp/balena",
+				"ReadOnly": false
+			}
 		],
 		"ContainerIDFile": "",
 		"LogConfig": {

--- a/test/lib/mockerode.ts
+++ b/test/lib/mockerode.ts
@@ -250,7 +250,7 @@ export function createContainer(container: PartialContainerInspectInfo) {
 	const fakeContainer = createFake(dockerode.Container.prototype);
 
 	return {
-		...fakeContainer, // by default all methods fail unless overriden
+		...fakeContainer, // by default all methods fail unless overridden
 		id,
 		inspectInfo,
 		info,

--- a/test/src/compose/application-manager.spec.ts
+++ b/test/src/compose/application-manager.spec.ts
@@ -15,6 +15,7 @@ import log from '../../../src/lib/supervisor-console';
 import { InstancedAppState } from '../../../src/types/state';
 
 import * as dbHelper from '../../lib/db-helper';
+import * as fsUtils from '../../../src/lib/fs-utils';
 
 const DEFAULT_NETWORK = Network.fromComposeObject('default', 1, 'appuuid', {});
 
@@ -179,6 +180,9 @@ describe('compose/application-manager', () => {
 		// Stub methods that depend on external dependencies
 		stub(imageManager, 'isCleanupNeeded');
 		stub(networkManager, 'supervisorNetworkReady');
+
+		// Stub mkdirp call for service manager bind directory creation
+		stub(fsUtils, 'mkdirp').resolves();
 	});
 
 	beforeEach(() => {

--- a/test/src/compose/service.spec.ts
+++ b/test/src/compose/service.spec.ts
@@ -485,6 +485,142 @@ describe('compose/service', () => {
 		});
 	});
 
+	describe('Configuring service volumes', () => {
+		it('should add bind mounts using the mounts API', async () => {
+			const s = await Service.fromComposeObject(
+				{
+					appId: 123456,
+					serviceId: 123456,
+					serviceName: 'test',
+					composition: {
+						volumes: ['myvolume:/myvolume'],
+						tmpfs: ['/var/tmp'],
+					},
+				},
+				{ appName: 'test' } as any,
+			);
+
+			// inject bind mounts (as feature labels would)
+			s.config.volumes.push('/sys:/sys:ro');
+			s.config.volumes.push(
+				`${constants.dockerSocket}:${constants.containerDockerSocket}`,
+			);
+
+			const c = s.toDockerContainer({ deviceName: 'foo' } as any);
+
+			expect(c)
+				.to.have.property('HostConfig')
+				.that.has.property('Mounts')
+				.that.deep.includes.members([
+					{
+						Type: 'volume',
+						Source: Volume.generateDockerName(123456, 'myvolume'),
+						Target: '/myvolume',
+						ReadOnly: false,
+					},
+					{
+						Type: 'bind',
+						Source: '/tmp/balena-supervisor/services/123456/test',
+						Target: '/tmp/resin',
+						ReadOnly: false,
+					},
+					{
+						Type: 'bind',
+						Source: '/tmp/balena-supervisor/services/123456/test',
+						Target: '/tmp/balena',
+						ReadOnly: false,
+					},
+					{
+						Type: 'bind',
+						Source: '/sys',
+						Target: '/sys',
+						ReadOnly: true,
+					},
+					{
+						Type: 'bind',
+						Source: constants.dockerSocket,
+						Target: constants.containerDockerSocket,
+						ReadOnly: false,
+					},
+					{
+						Type: 'tmpfs',
+						Target: '/var/tmp',
+					},
+				]);
+		});
+
+		it('should obtain the service volume config from docker configuration', () => {
+			const mockContainer = createContainer({
+				Id: 'deadbeef',
+				Name: 'main_431889_572579',
+				HostConfig: {
+					// Volumes with Bind configs are ignored since
+					// the Supervisor uses explicit Mounts for volumes
+					Binds: ['ignoredvolume:/ignoredvolume'],
+					Tmpfs: {
+						'/var/tmp1': '',
+					},
+					Mounts: [
+						{
+							Type: 'volume',
+							Source: 'testvolume',
+							Target: '/testvolume',
+							ReadOnly: false,
+						},
+						{
+							Type: 'bind',
+							Source: '/proc',
+							Target: '/proc',
+							ReadOnly: true,
+						},
+						{
+							Type: 'bind',
+							Source: '/sys',
+							Target: '/sys',
+							ReadOnly: true,
+						},
+						{
+							Type: 'volume',
+							Source: 'anothervolume',
+							Target: '/anothervolume',
+							ReadOnly: false,
+						},
+						{
+							Type: 'tmpfs',
+							Source: '',
+							Target: '/var/tmp2',
+						},
+					],
+				},
+				Config: {
+					Volumes: {
+						'/var/lib/volume': {},
+					},
+					Labels: {
+						'io.resin.app-id': '1011165',
+						'io.resin.architecture': 'armv7hf',
+						'io.resin.service-id': '43697',
+						'io.resin.service-name': 'main',
+						'io.resin.supervised': 'true',
+					},
+				},
+			});
+			const s = Service.fromDockerContainer(mockContainer.inspectInfo);
+			expect(s.config)
+				.to.have.property('volumes')
+				.that.deep.equals([
+					'/var/lib/volume',
+					'testvolume:/testvolume',
+					'/proc:/proc:ro',
+					'/sys:/sys:ro',
+					'anothervolume:/anothervolume',
+				]);
+			expect(s.config)
+				.to.have.property('tmpfs')
+				.that.deep.equals(['/var/tmp1', '/var/tmp2']);
+		});
+	});
+
 	describe('Comparing services', () => {
 		describe('Comparing array parameters', () => {
 			it('Should correctly compare ordered array parameters', async () => {
@@ -591,6 +727,75 @@ describe('compose/service', () => {
 					{ appName: 'test' } as any,
 				);
 				expect(svc1.isEqualConfig(svc2, {})).to.be.true;
+			});
+		});
+
+		describe('Comparing volume bind mounts for services', () => {
+			it('should distinguish between volumes using HostConfig.Mounts and HostConfig.Binds', async () => {
+				const ctnWithBinds = await createContainer({
+					Id: 'deadfeet',
+					Name: 'main_1111_2222_abcd',
+					HostConfig: {
+						Binds: [
+							'myvolume:/myvolume',
+							'/tmp/balena-supervisor/services/1234567/main:/tmp/resin',
+							'/tmp/balena-supervisor/services/1234567/main:/tmp/balena',
+						],
+					},
+					Config: {
+						Labels: {
+							'io.resin.app-id': '1234567',
+							'io.resin.architecture': 'amd64',
+							'io.resin.service-id': '43697',
+							'io.resin.service-name': 'main',
+							'io.resin.supervised': 'true',
+						},
+					},
+				});
+				const svcWithBinds = await Service.fromDockerContainer(
+					ctnWithBinds.inspectInfo,
+				);
+
+				const ctnWithMounts = await createContainer({
+					Id: 'deadfeet',
+					Name: 'main_1111_2222_abcd',
+					HostConfig: {
+						Mounts: [
+							{
+								Type: 'volume',
+								Source: 'myvolume',
+								Target: '/myvolume',
+								ReadOnly: false,
+							},
+							{
+								Type: 'bind',
+								Source: '/tmp/balena-supervisor/services/1234567/main',
+								Target: '/tmp/resin',
+								ReadOnly: false,
+							},
+							{
+								Type: 'bind',
+								Source: '/tmp/balena-supervisor/services/1234567/main',
+								Target: '/tmp/balena',
+								ReadOnly: false,
+							},
+						],
+					},
+					Config: {
+						Labels: {
+							'io.resin.app-id': '1234567',
+							'io.resin.architecture': 'amd64',
+							'io.resin.service-id': '43697',
+							'io.resin.service-name': 'main',
+							'io.resin.supervised': 'true',
+						},
+					},
+				});
+				const svcWithMounts = await Service.fromDockerContainer(
+					ctnWithMounts.inspectInfo,
+				);
+
+				expect(svcWithBinds.isEqualConfig(svcWithMounts, {})).to.be.false;
 			});
 		});
 	});


### PR DESCRIPTION
When using the binds api the docker engine will auto-create the host
path as a directory if it doesn't exist. This can lead to unintended
side-effects when the source is a file (like when bind-mounting the
docker socket), as seen in the linked issue.

Closes https://github.com/balena-os/balena-supervisor/issues/1231

Change-type: major
Signed-off-by: Robert Günzler <robertg@balena.io>
Co-authored-by: Christina Wang <christina@balena.io>