### PR TITLE
Improve network interface filter

### DIFF
--- a/src/network.ts
+++ b/src/network.ts
@@ -116,7 +116,7 @@ export const connectivityCheckEnabled = Bluebird.method(
 	() => isConnectivityCheckEnabled,
 );
 
-const IP_REGEX = /^(?:balena|docker|rce|tun)[0-9]+|tun[0-9]+|resin-vpn|lo|resin-dns|supervisor0|balena-redsocks|resin-redsocks|br-[0-9a-f]{12}$/;
+const IP_REGEX = /^(?:(?:balena|docker|rce|tun)[0-9]+|tun[0-9]+|resin-vpn|lo|resin-dns|supervisor0|balena-redsocks|resin-redsocks|br-[0-9a-f]{12})$/;
 
 export const shouldReportInterface = (intf: string) => !IP_REGEX.test(intf);
 


### PR DESCRIPTION
The supervisor filters out some network interfaces for mac address
reporting, to remove (balena*,lo,tun*,etc). The previous filter was
matching any interface containing in one of the defined filters, making
it stricter than necessary. This commit fixes the issue

Change-type: patch