### PR TITLE
Create supervisor docker-compose

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -1,5 +1,5 @@
 name: balena-supervisor
-description: 'Balena Supervisor: balena''s agent on devices.'
+description: "Balena Supervisor: balena's agent on devices."
 joinable: false
 type: sw.application
 version: 12.10.14

--- a/circle.yml
+++ b/circle.yml
@@ -71,10 +71,10 @@ defaults: &defaults
           export TAG=$(echo ${CIRCLE_BRANCH} | sed 's/[^a-z0-9A-Z_.-]/-/g')
           export ARCH=${ARCH}
           export PROJECT_NAME=${ARCH}-supervisor
-          export SERVICE_NAME=main
+          export SERVICE_NAME=balena-supervisor
           # start the build for this architecture
           bash automation/build.sh
-          if [ "${CIRCLE_BRANCH}" = "master" ] && [ "${AUTHOR}" = "balena-ci"] && [ "${COMMITTER}" = "versionbot@balena.io" ] && [ "${DEPLOY_TO_STAGING}" = "true" ]; then
+          if [ "${CIRCLE_BRANCH}" = "master" ] && [ "${AUTHOR}" = "balena-ci" ] && [ "${COMMITTER}" = "versionbot@balena.io" ] && [ "${DEPLOY_TO_STAGING}" = "true" ]; then
             echo "Deploying to balena API (staging)"
             BALENARC_BALENA_URL=$STAGING_API_ENDPOINT balena login --token $STAGING_API_TOKEN
             # Create a draft release first in case the second step fails
@@ -90,7 +90,7 @@ defaults: &defaults
             # Cleanup credentials just in case
             rm ~/.balena/token
           fi
-          if [ "${CIRCLE_BRANCH}" = "master" ] && [ "${AUTHOR}" = "balena-ci"] && [ "${COMMITTER}" = "versionbot@balena.io" ] && [ "${DEPLOY_TO_PRODUCTION}" = "true" ]; then
+          if [ "${CIRCLE_BRANCH}" = "master" ] && [ "${AUTHOR}" = "balena-ci" ] && [ "${COMMITTER}" = "versionbot@balena.io" ] && [ "${DEPLOY_TO_PRODUCTION}" = "true" ]; then
             echo "Deploying to balena API (production)"
             BALENARC_BALENA_URL=$PRODUCTION_API_ENDPOINT balena login --token $PRODUCTION_API_TOKEN
             # Create a draft release first in case the second step fails

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2.1'
+
+services:
+  # This service can only be named `main` or `balena-supervisor` as older
+  # devices will keep relying on the `/v6/supervisor_release` endpoint that
+  # identifies the supervisor image by that service name.
+  balena-supervisor:
+    build: ./
+    privileged: true
+    tty: true
+    restart: always
+    network_mode: host
+    labels:
+      io.balena.features.balena-api: '1'
+      io.balena.features.dbus: '1'
+      io.balena.features.balena-socket: '1'


### PR DESCRIPTION
Creates supervisor docker-compose for creating releases on balena-cloud. This will allow the supervisor service to be correctly named when querying the API.

Change-type: patch