### PR TITLE
Do not build for staging in circleci job

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -62,11 +62,7 @@ defaults: &defaults
           else
             export DEPLOY_TO_PRODUCTION=false
           fi
-          if [ "$STAGING_API_TOKEN" != "" ]; then
-            export DEPLOY_TO_PRODUCTION=${DEPLOY_TO_STAGING}
-          else
-            export DEPLOY_TO_STAGING=false
-          fi
+          export DEPLOY_TO_STAGING=false
           # Create required env vars
           export TAG=$(echo ${CIRCLE_BRANCH} | sed 's/[^a-z0-9A-Z_.-]/-/g')
           export ARCH=${ARCH}


### PR DESCRIPTION
Since we have balena-ci action building releases for staging we can remove the circleci code that does this as well.

I didn't remove all the staging code in the job because we are going to delete the entire file once we use the action for production.