### PR TITLE
Log entire Exception if message is empty

### DIFF
--- a/src/device-state/current-state.ts
+++ b/src/device-state/current-state.ts
@@ -246,8 +246,9 @@ function reportCurrentState(attempts = 0) {
 						e.retryAfter ?? MINIMUM_BACKOFF_DELAY,
 					);
 				} else {
+					// If the exception message is empty then log entire exception object for troubleshooting
 					eventTracker.track('Device state report failure', {
-						error: e.message,
+						error: e.message.length > 0 ? e.message : e,
 					});
 					backoff(reportCurrentState, stateReportErrors++, maxDelay);
 				}


### PR DESCRIPTION
The log message `Event: Device state report failure {"error":{"message":""}}` is only found here. It doesn't find the root cause but this will help to pin it down instead of seeing this incredibly annoying message. Ideally this change just leads to the discovery of the root cause.

related to https://github.com/balena-os/balena-supervisor/issues/1680