### PR TITLE
Change repo type to skip concourse build

### DIFF
--- a/repo.yml
+++ b/repo.yml
@@ -1,4 +1,4 @@
-type: docker
+type: generic
 
 backports:
   next: 11.9.x


### PR DESCRIPTION
Testing and building is now done on balena builders. This sets the repo type to generic to avoid unnecessary checks

Change-type: patch