### PR TITLE
Fix `delete-then-download` strategy

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
 		"inlineSourceMap": true,
 		"outDir": "./build/",
 		"skipLibCheck": true,
-		"lib": ["es6"],
+		"lib": ["es2019"],
 		"resolveJsonModule": true,
 		"allowJs": true
 	},


### PR DESCRIPTION
The strategy has been broken for a while but it was not clear how to
fix it before the changes to image management. This PR fixes application
manager to remove images before downloading the new image. This will
only have an effect on changing images.

Closes: #1233
Change-type: patch