### PR TITLE
Bootstrap supervisor configuration on container start

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -8,6 +8,7 @@ ARG NODE_VERSION
 ARG NODE_ARCHIVE="node-no-intl-v${NODE_VERSION}-linux-alpine-${ARCH}.tar.gz"
 ARG S3_BASE="https://resin-packages.s3.amazonaws.com"
 ARG NODE_LOCATION="${S3_BASE}/node/v${NODE_VERSION}/${NODE_ARCHIVE}"
+ENV SUPERVISOR_ARCH=${ARCH}
 
 # DO NOT REMOVE THE cross-build-* COMMANDS
 # The following commands are absolutely needed. When we
@@ -33,6 +34,7 @@ RUN apk add --no-cache \
 	libuv \
 	sqlite-libs \
 	sqlite-dev \
+	jq \
 	dbus-dev
 
 COPY build-utils/node-sums.txt .
@@ -51,6 +53,7 @@ RUN npm ci --build-from-source --sqlite=/usr/lib
 # We only run these commands when executing through
 # livepush, so they are presented as livepush directives
 #dev-run=apk add --no-cache ip6tables iptables
+#dev-copy=setenv.sh .
 #dev-copy=entry.sh .
 #dev-cmd-live=LIVEPUSH=1 ./entry.sh
 
@@ -99,6 +102,7 @@ RUN apk add --no-cache \
 	avahi \
 	dbus \
 	libstdc++ \
+	jq \
 	sqlite-libs
 
 WORKDIR /usr/src/app
@@ -109,17 +113,14 @@ COPY --from=BUILD /usr/src/app/package.json ./
 COPY --from=BUILD /usr/src/app/node_modules ./node_modules
 
 COPY entry.sh .
+COPY setenv.sh .
 
 RUN mkdir -p rootfs-overlay && \
 	(([ ! -d rootfs-overlay/lib64 ] && ln -s /lib rootfs-overlay/lib64) || true)
 
 ARG ARCH
-ARG VERSION=master
 ARG DEFAULT_MIXPANEL_TOKEN=bananasbananas
-ENV CONFIG_MOUNT_POINT=/boot/config.json \
-	LED_FILE=/dev/null \
-	SUPERVISOR_IMAGE=balena/$ARCH-supervisor \
-	VERSION=$VERSION \
+ENV SUPERVISOR_ARCH=${ARCH} \
 	DEFAULT_MIXPANEL_TOKEN=$DEFAULT_MIXPANEL_TOKEN
 COPY avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 

--- a/setenv.sh
+++ b/setenv.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+set -a
+
+# read key from <key>="<value>" config file
+read_config() {
+  sed -n "s/^$1=\"\(.*\)\"$/\1/p" $2 2>/dev/null
+}
+
+# apply filter to json file and return raw output
+# return default if the filter does not exist
+read_json() {
+  [ "$(jq -r $1 $2 2>/dev/null)" != "null" ] && jq -r $1 $2 || echo -n $3
+}
+
+# Setup paths
+ROOT_MOUNTPOINT=${ROOT_MOUNTPOINT:-/mnt/root}
+BOOT_MOUNTPOINT=${BOOT_MOUNTPOINT:-/mnt/boot}
+
+# Useful short aliases
+_root=${ROOT_MOUNTPOINT}
+_boot=${ROOT_MOUNTPOINT}${BOOT_MOUNTPOINT}
+_data=${ROOT_MOUNTPOINT}/mnt/data
+
+# Config mountpoint is still used by migrations
+CONFIG_MOUNT_POINT=${CONFIG_MOUNT_POINT:-${_boot}/config.json}
+APPS_JSON_PATH=${APPS_JSON_PATH:-${_data}/apps.json}
+DATABASE_PATH=${_data}/resin-data/balena-supervisor/database.sqlite
+
+# Set docker configuration
+DOCKER_SOCKET=${DOCKER_SOCKET:-${ROOT_MOUNTPOINT}/var/run/balena-engine.sock}
+DOCKER_HOST=${DOCKER_HOST:-unix://${DOCKER_SOCKET}}
+
+# Dbus socket
+DBUS_SYSTEM_BUS_ADDRESS="unix:path=${ROOT_MOUNTPOINT}/run/dbus/system_bus_socket"
+
+# Use a trick to get the container id from inside the container itself in
+# in case the supervisor is started some other way than with the start-resin-supervisor
+# script. This will not work with cgrous v2
+# https://stackoverflow.com/a/25729598
+if [ -z "${SUPERVISOR_CONTAINER_ID}" ]; then
+	SUPERVISOR_CONTAINER_ID=$(cat /proc/self/cgroup | grep -o  -e "docker-.*.scope" | head -n 1 | sed "s/docker-\(.*\).scope/\\1/")
+fi
+
+# Supervisor environment variables
+SUPERVISOR_VERSION=$(read_json .version package.json -n)
+SUPERVISOR_IMAGE=${SUPERVISOR_IMAGE:-$(curl -XGET --unix-socket "${DOCKER_SOCKET}" \
+  "http://localhost/containers/${SUPERVISOR_CONTAINER_ID}/json" | jq -r .Image 2>/dev/null \
+  || echo -n "balena/${SUPERVISOR_ARCH}-supervisor")}
+
+# Container service variables
+BALENA_DEVICE_TYPE=${BALENA_DEVICE_TYPE:-$(read_json .slug ${_boot}/device-type.json)}
+BALENA_DEVICE_ARCH=${BALENA_DEVICE_ARCH:-$(read_json .arch ${_boot}/device-type.json)}
+BALENA_HOST_OS_VERSION=${BALENA_HOST_OS_VERSION:-$(read_config 'PRETTY_NAME' ${_root}/etc/os-release)}
+BALENA_HOST_OS_META_RELEASE=$(read_config 'META_BALENA_VERSION' ${_root}/etc/os-release)
+BALENA_HOST_OS_VARIANT=$(read_config 'VARIANT_ID' ${ROOTDIR}/etc/os-release)
+if [ -n "$(read_json .developmentMode ${_boot}/config.json)" ]; then
+  BALENA_HOST_OS_VARIANT=$([ "$(read_json .developmentMode ${_boot}/config.json )" = "true" ] && echo -n "dev" || echo -n "prod")
+fi
+
+# Other defaults
+LED_FILE=${LED_FILE:-/dev/null}
+LISTEN_PORT=${LISTEN_PORT:-$(read_json .listenPort ${_boot}/config.json 48484)}


### PR DESCRIPTION
This change goes in line with making the supervisor more like an app. This
reduces the number of parameters that need to be given to start the
supervisor container, moving it closer to something that could be
started by the supervisor itself. This should allow to greatly simplify
the supervisor [start script](https://github.com/balena-os/meta-balena/blob/master/meta-balena-common/recipes-containers/balena-supervisor/balena-supervisor/start-balena-supervisor)

This is now the minimal startup configuration for the container

```
balena run --privileged --name balena_supervisor \
	--restart=always \
	--net=host \
	--cidenv=SUPERVISOR_CONTAINER_ID \
	--mount type=bind,source=/var/run/balena-engine.sock,target=/var/run/balena-engine.sock \
	--mount type=bind,source=/,target=/mnt/root \
	-e DOCKER_SOCKET=/var/run/balena-engine.sock \
	"${SUPERVISOR_IMAGE}:${SUPERVISOR_TAG}"
```

Change-type: patch