### PR TITLE
Device state patch controls

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -25,6 +25,7 @@ This list contains configuration variables that can be used with all balena devi
 | BALENA_HOST_DISCOVERABILITY | boolean | false | true | Enable / Disable Avahi to run which will allow the device to respond to requests such as network scans. | v11.9.2 |
 | BALENA_HOST_SPLASH_IMAGE | integer | true | /boot/splash/balena-logo-default.png | Allows changing splash screen on boot to user defined file from userspace. | v12.3.0 |
 | BALENA_SUPERVISOR_HARDWARE_METRICS | boolean | false | true | Toggle hardware metrics reporting to the cloud, which occurs every 10 seconds when there are changes. Metrics include CPU utilization, CPU temperature, memory usage, and disk space. Useful for devices with bandwidth sensitivity. | v12.8.0 |
+| BALENA_SUPERVISOR_PATCH_INTERVAL | integer | false | 60000 | Define the frequency of updating the cloud with device's statel in milliseconds. The minimum value for this variable is defined by the balenaCloud backend, and may vary. | v12.12.0 |
 
 ---
 

--- a/src/config/schema-type.ts
+++ b/src/config/schema-type.ts
@@ -58,6 +58,10 @@ export const schemaTypes = {
 		type: PermissiveNumber,
 		default: NullOrUndefined,
 	},
+	statePatchInterval: {
+		type: PermissiveNumber,
+		default: 60000,
+	},
 	appUpdatePollInterval: {
 		type: PermissiveNumber,
 		default: 60000,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -49,6 +49,11 @@ export const schema = {
 		mutable: false,
 		removeIfNull: false,
 	},
+	statePatchInterval: {
+		source: 'config.json',
+		mutable: true,
+		removeIfNull: false,
+	},
 	appUpdatePollInterval: {
 		source: 'config.json',
 		mutable: true,

--- a/src/device-config.ts
+++ b/src/device-config.ts
@@ -115,6 +115,11 @@ const actionExecutors: DeviceActionExecutors = {
 const configBackends: ConfigBackend[] = [];
 
 const configKeys: Dictionary<ConfigOption> = {
+	statePatchInterval: {
+		envVarName: 'SUPERVISOR_PATCH_INTERVAL',
+		varType: 'int',
+		defaultValue: '60000',
+	},
 	appUpdatePollInterval: {
 		envVarName: 'SUPERVISOR_POLL_INTERVAL',
 		varType: 'int',

--- a/src/lib/backoff.ts
+++ b/src/lib/backoff.ts
@@ -1,0 +1,37 @@
+import { log } from '../lib/supervisor-console';
+import sleep from '../lib/sleep';
+
+/**
+ * Perform exponential backoff on the function, increasing the attempts
+ * counter on each call
+ *
+ * If attempts is 0 then, it will delay for min(minDelay, maxDelay)
+ */
+export const backoff = (
+	retry: (attempts: number) => void,
+	attempts = 0,
+	maxDelay: number,
+	minDelay: number,
+) => {
+	const delay = Math.min(2 ** attempts * minDelay, maxDelay);
+	log.info(`Retrying in ${delay / 1000} seconds`);
+	setTimeout(() => retry(attempts + 1), delay);
+};
+
+/**
+ * Perform exponential backoff on an async function, increasing the attempts
+ * counter on each call
+ *
+ * If attempts is 0 then, it will delay for min(minDelay, maxDelay)
+ */
+export async function backoffPromise(
+	retry: (attempts: number) => Promise<void>,
+	attempts = 0,
+	maxDelay: number,
+	minDelay: number,
+): Promise<void> {
+	const delay = Math.min(2 ** attempts * minDelay, maxDelay);
+	log.info(`Retrying in ${delay / 1000} seconds`);
+	await sleep(delay);
+	return retry(attempts + 1);
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -64,8 +64,6 @@ const constants = {
 	backoffIncrement: 500,
 	supervisorNetworkSubnet: '10.114.104.0/25',
 	supervisorNetworkGateway: '10.114.104.1',
-	// How often can we report our state to the server in ms
-	maxReportFrequency: 10 * 1000,
 	// How much of a jitter we can add to our api polling
 	// (this number is used as an upper bound when generating
 	// a random jitter)

--- a/src/lib/sleep.ts
+++ b/src/lib/sleep.ts
@@ -1,0 +1,6 @@
+/**
+ * Delays for input ms before resolving
+ */
+export default async function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Previously there was no way to control how frequently the device reported its current state. This PR adds config vars that let the cloud specify intervals for:

 - [x] current state patching via `BALENA_SUPERVISOR_PATCH_INTERVAL`
 - [ ] device metric patching via `BALENA_SUPERVISOR_METRICS_INTERVAL`
 - [ ] download progress patching via `BALENA_SUPERVISOR_DOWNLOAD_UPDATE_INTERVAL` ?