### PR TITLE
Fix .local dns resolution when returning multiple addresses 

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,5 @@
 import { NOTFOUND } from 'dns';
 import * as mdnsResolver from 'mdns-resolver';
-import '@balena/happy-eyeballs/eye-patch';
 
 class DnsLookupError extends Error {
 	public constructor(public code: string = NOTFOUND) {
@@ -118,6 +117,7 @@ interface DnsLookupOpts {
 	};
 })();
 
+import '@balena/happy-eyeballs/eye-patch';
 import Supervisor from './supervisor';
 
 const supervisor = new Supervisor();

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,7 +11,10 @@ class DnsLookupError extends Error {
 interface DnsLookupCallback {
 	(err: any): void;
 	(err: undefined | null, address: string, family: number): void;
-	(err: undefined | null, addresses: string[]): void;
+	(
+		err: undefined | null,
+		addresses: Array<{ address: string; family: number }>,
+	): void;
 }
 
 interface DnsLookupOpts {
@@ -75,9 +78,9 @@ interface DnsLookupOpts {
 						.catch(() => {
 							return '';
 						})
-						.then((addr) => {
+						.then((address) => {
 							return {
-								addr,
+								address,
 								family,
 							};
 						});
@@ -87,7 +90,7 @@ interface DnsLookupOpts {
 			// resolve the addresses...
 			return Promise.all(getResolvers()).then((results) => {
 				// remove any that didn't resolve...
-				let allAddresses = results.filter((result) => result.addr !== '');
+				let allAddresses = results.filter((result) => result.address !== '');
 
 				// unless the results should be returned verbatim, sort them so v4 comes first...
 				if (opts && typeof opts !== 'number' && !opts.verbatim) {
@@ -102,15 +105,12 @@ interface DnsLookupOpts {
 
 				// all the addresses were requested...
 				if (opts && typeof opts !== 'number' && opts.all) {
-					return cb(
-						null,
-						allAddresses.map((r) => r.addr),
-					);
+					return cb(null, allAddresses);
 				}
 
 				// only a single address was requested...
-				const [{ addr, family }] = allAddresses;
-				return cb(null, addr, family);
+				const [{ address, family }] = allAddresses;
+				return cb(null, address, family);
 			});
 		}
 


### PR DESCRIPTION
The supervisor performs its own local resolution for `.local`
addresses due to a limitation in [musl](https://wiki.musl-libc.org/future-ideas.html).
The resolution function was not following exactly the nodejs [dns.lookup
specification](https://nodejs.org/api/dns.html#dnslookuphostname-options-callback)
which could cause certain clients to fail (in this case happy-eyeballs). This
updates the function to follow the specification.

This PR also ensures the happy-eyeballs patch continues working with `.local` addresses.

Change-type: patch

