### PR TITLE
Write sync config json

### DIFF
--- a/src/lib/fs-utils.ts
+++ b/src/lib/fs-utils.ts
@@ -27,7 +27,7 @@ export async function writeFileAtomic(
 	data: string | Buffer,
 ): Promise<void> {
 	await writeAndSyncFile(`${pathName}.new`, data);
-	await fs.rename(`${pathName}.new`, pathName);
+	await safeRename(`${pathName}.new`, pathName);
 }
 
 export async function safeRename(src: string, dest: string): Promise<void> {


### PR DESCRIPTION
Use `writeAndSync` when writing to config.json

`/mnt/boot` is a vfat partition which does not support atomic file
rename. The best course of action is to write and sync as fast as
possible to prevent corruption (although it still may happen)

Change-type: patch