### PR TITLE
Implement `SUPERVISOR_REPORT_INTERVAL` config var

### DIFF
--- a/src/api-binder.ts
+++ b/src/api-binder.ts
@@ -268,13 +268,28 @@ export async function provisionDependentDevice(
 	).timeout(conf.apiTimeout)) as Device;
 }
 
-export function startCurrentStateReport() {
+export async function startCurrentStateReport() {
 	if (balenaApi == null) {
 		throw new InternalInconsistencyError(
 			'Trying to start state reporting without initializing API client',
 		);
 	}
-	startReporting();
+
+	// Get interval for sending current state
+	const reportInterval = await config.get('stateReportInterval');
+
+	// Store reporting cancelation if reportInterval changes
+	let reporting = startReporting(reportInterval);
+
+	// If stateReportInterval changed then reset reporting interval
+	config.on('change', (changedConfig: any) => {
+		if (changedConfig.stateReportInterval != null) {
+			// Clear previous reporting state
+			reporting.cancel();
+			// Set reporting again with new value
+			reporting = startReporting(changedConfig.stateReportInterval);
+		}
+	});
 }
 
 export async function fetchDeviceTags(): Promise<DeviceTag[]> {

--- a/src/config/schema-type.ts
+++ b/src/config/schema-type.ts
@@ -58,6 +58,10 @@ export const schemaTypes = {
 		type: PermissiveNumber,
 		default: NullOrUndefined,
 	},
+	stateReportInterval: {
+		type: PermissiveNumber,
+		default: 10000,
+	},
 	appUpdatePollInterval: {
 		type: PermissiveNumber,
 		default: 60000,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -190,6 +190,11 @@ export const schema = {
 		mutable: true,
 		removeIfNull: false,
 	},
+	stateReportInterval: {
+		source: 'db',
+		mutable: true,
+		removeIfNull: false,
+	},
 };
 
 export type Schema = typeof schema;

--- a/src/device-config.ts
+++ b/src/device-config.ts
@@ -115,6 +115,11 @@ const actionExecutors: DeviceActionExecutors = {
 const configBackends: ConfigBackend[] = [];
 
 const configKeys: Dictionary<ConfigOption> = {
+	stateReportInterval: {
+		envVarName: 'SUPERVISOR_REPORT_INTERVAL',
+		varType: 'int',
+		defaultValue: '10000',
+	},
 	appUpdatePollInterval: {
 		envVarName: 'SUPERVISOR_POLL_INTERVAL',
 		varType: 'int',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -67,8 +67,6 @@ const constants = {
 	backoffIncrement: 500,
 	supervisorNetworkSubnet: '10.114.104.0/25',
 	supervisorNetworkGateway: '10.114.104.1',
-	// How often can we report our state to the server in ms
-	maxReportFrequency: 10 * 1000,
 	// How much of a jitter we can add to our api polling
 	// (this number is used as an upper bound when generating
 	// a random jitter)


### PR DESCRIPTION
This PR simply lifts all the intervals/listeners/queues to a function that monitors for changes to device configs. If `SUPERVISOR_REPORT_INTERVAL` changes, the reporting passed back from `startReporting` is cancelled and started again with the new value.