### PR TITLE
Added PR template doc

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+*If this is a regression, consider adding it to #1898!*
+
+# Description
+
+Please include a summary of the change and which issue was fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+# Type of change
+
+Include at least one commit in your PR that marks the change-type. This can be either specified through a Change-type footer, or by adding the change-type as a prefix to the commit, i.e. minor: Add some new feature. This is so the PR can be automatically versioned and a changelog generated for it by using versionist. Check out [semver](https://semver.org/) for a detailed explanation of the different possible change-type values.
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 


### PR DESCRIPTION
Useful to convey information to new contributors but mainly to remind people to add regressions to https://github.com/balena-os/balena-supervisor/issues/1898

based on https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository, this file should be shown on new PR requests