### PR TITLE
Always add status to image download report

### DIFF
--- a/src/compose/images.ts
+++ b/src/compose/images.ts
@@ -193,7 +193,11 @@ export async function triggerFetch(
 	}
 
 	const onProgress = (progress: FetchProgressEvent) => {
-		reportEvent('update', { ...image, downloadProgress: progress.percentage });
+		reportEvent('update', {
+			...image,
+			downloadProgress: progress.percentage,
+			status: 'Downloading',
+		});
 	};
 
 	let success: boolean;
@@ -261,7 +265,7 @@ export async function triggerFetch(
 		}
 	}
 
-	reportEvent('finish', image);
+	reportEvent('finish', { ...image, status: 'Downloaded' });
 	onFinish(success);
 }
 


### PR DESCRIPTION
It seems that in some cases the supervisor can report
an image without a `status` field leading to a cloud side 401 response. This should fix the issue even 
though we don't have a clear replication.

Relates to: #1905

Change-type: patch