### PR TITLE
Remove restrictions on docker env vars

### DIFF
--- a/test/06-validation.spec.ts
+++ b/test/06-validation.spec.ts
@@ -330,7 +330,7 @@ describe('validation', () => {
 											id: 45,
 											image_id: 34,
 											image: 'foo',
-											environment: { ' aaa': '123' },
+											environment: { 'bbb=aaa': '123' },
 											labels: {},
 										},
 									},


### PR DESCRIPTION
Docker doesn't impose any restrictions on the contents of an env
var, and neither does the CLI and API so it doesn't make much sense
for the env var to be as restrictive.

Change-type: patch