### PR TITLE
Add compose support for volumes defined with long syntax

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -3,3 +3,5 @@ description: 'Balena Supervisor: balena''s agent on devices.'
 joinable: false
 type: sw.application
 version: 13.1.7
+provides:
+  - slug: sw.compose.long-volume-syntax

--- a/src/compose/sanitise.ts
+++ b/src/compose/sanitise.ts
@@ -65,7 +65,7 @@ export function sanitiseComposeConfig(
 ): ServiceComposeConfig {
 	const filtered: string[] = [];
 	const toReturn = _.pickBy(composeConfig, (_v, k) => {
-		const included = _.includes(supportedComposeFields, k);
+		const included = supportedComposeFields.includes(k);
 		if (!included) {
 			filtered.push(k);
 		}

--- a/src/compose/volume-manager.ts
+++ b/src/compose/volume-manager.ts
@@ -32,7 +32,7 @@ export async function getAll(): Promise<Volume[]> {
 			volumesList.push(volume);
 		} catch (err) {
 			if (err instanceof InternalInconsistencyError) {
-				log.debug(`Found unmanaged Volume: ${volumeInfo.Name}`);
+				log.debug(`Found unmanaged or anonymous Volume: ${volumeInfo.Name}`);
 			} else {
 				throw err;
 			}

--- a/test/22-local-mode.spec.ts
+++ b/test/22-local-mode.spec.ts
@@ -375,7 +375,6 @@ describe('LocalModeManager', () => {
 		it('stores snapshot and retrieves from the db', async () => {
 			await localMode.storeEngineSnapshot(recordSample);
 			const retrieved = await localMode.retrieveLatestSnapshot();
-			console.log(retrieved);
 			expect(retrieved).to.be.deep.equal(recordSample);
 		});
 

--- a/test/src/compose/volume-manager.spec.ts
+++ b/test/src/compose/volume-manager.spec.ts
@@ -95,7 +95,7 @@ describe('compose/volume-manager', () => {
 					]);
 					// Check that debug message was logged saying we found a Volume not created by us
 					expect(logDebug.lastCall.lastArg).to.equal(
-						'Found unmanaged Volume: decoy',
+						'Found unmanaged or anonymous Volume: decoy',
 					);
 				},
 				{ volumes: volumeData },


### PR DESCRIPTION
balena-compose already supports long syntax, and with this PR, Supervisor can
have the option of using HostConfig.Mounts for internal bind mounts such as
ones added by feature labels. This will be handled in a future PR.

The only blocker to having users use long syntax is adding this feature
to the state machine. This PR does not add that feature.

Relates-to: https://github.com/balena-os/balena-supervisor/pull/1780
Relates-to: https://github.com/balena-os/balena-engine/issues/220
Relates-to: #1933
Change-type: patch
Signed-off-by: Christina Wang <christina@balena.io>

# How Has This Been Tested?

1. Place device in local mode
2. POST /v2/local/target-state with a target state containing the following compose for services.volumes:
```
{ 
  "volumes": [
      "/mnt/data:/home/bind", // should be ignored
      "named:/home/named",
      "/usr/src/app/anonymous", 
      {
          "type": "volume",
          "target": "/usr/src/app/anonymous2",
          "volume": {
              "nocopy": true
          }
      },
      {
          "type": "volume",
          "source": "named2",
          "target": "/home/named2"
      },
      {
          "type": "bind", // should be ignored
          "source": "/home/root",
          "target": "/home/bind2",
          "bind": {
              "propagation": "slave"
          }
      },
      {
          "type": "tmpfs",
          "target": "/usr/src/app/tmp",
          "tmpfs": {
              "size": 2000
          }
      },
      {
          "type": "bind", // should be invalid
          "target": "/no_source"
      },
      {
          "type": "bind", // should be invalid
          "source": "not_an_absolute_path",
          "target": "/bind"
      },
      {
          "type": "tmpfs", // should be invalid
          "source": "should_not_have_source",
          "target": "/home/tmp"
      },
      {
          "type": "invalid", // should be invalid
          "source": "test",
          "target": "test2"
      }
  ]
}
```
The expected behavior is that binds will be filtered out and log a warning, same with invalid compose definitions. Additionally, the following volume types will be exposed in the following sections of container inspect info:
- Short syntax anonymous volumes -- `Config.Volumes`
- Long syntax anonymous volumes -- `HostConfig.Mounts`
- `tmpfs` volumes defined under compose's `service.volumes` -- `HostConfig.Mounts`
- `tmpfs` volumes defined under compose's `service.tmpfs` -- `HostConfig.Tmpfs`
- Short syntax named volumes -- `HostConfig.Binds`
- Long syntax named volumes -- `HostConfig.Mounts`
 
3. When inspecting the resulting container, all is as expected:
```
root@nuc:~# balena inspect $(balena ps -aq -f name=lock) | jq -r '.[].HostConfig | {Mounts,Binds,Tmpfs}'

{                                                                                                                            
  "Mounts": [                                                                                                                
    {                                                                                                                        
      "Type": "volume",                                                                                                      
      "Target": "/usr/src/app/anonymous2",
      "VolumeOptions": {
        "NoCopy": true
      }
    },
    {
      "Type": "volume",
      "Source": "1907314_named2",
      "Target": "/home/named2"
    },
    {
      "Type": "tmpfs",
      "Target": "/usr/src/app/tmp",
      "TmpfsOptions": {
        "SizeBytes": 2000
      }
    }
  ],
  "Binds": [
    "1907314_named:/home/named",
    "/tmp/balena-supervisor/services/1907314/lock:/tmp/resin",
    "/tmp/balena-supervisor/services/1907314/lock:/tmp/balena",
  ],
  "Tmpfs": null
}

// And for Config.Volumes:
"Volumes": {                                                                                                     
    "/usr/src/app/anonymous": {}                                                                                 
}
```
Note that volumes defined with long syntax are also namespaced by appId.

Logs contain warnings for bind mounts and invalid compose definitions:
```
[warn]    Ignoring invalid bind mount /mnt/data:/home/bind
[warn]    Ignoring invalid bind mount {"type":"bind","source":"/home/root","target":"/home/bind2","bind":{"propagation":"slave"}}
[warn]    Ignoring invalid compose volume definition {"type":"bind","target":"/no_source"}
[warn]    Ignoring invalid compose volume definition {"type":"bind","source":"not_an_absolute_path","target":"/bind"}
[warn]    Ignoring invalid compose volume definition {"type":"tmpfs","source":"should_not_have_source","target":"/home/tmp"}
[warn]    Ignoring invalid compose volume definition {"type":"invalid","source":"test","target":"test2"}
```
The reasons each of the above compose definitions are invalid are commented in my changes in `service.spec.ts`.

`balena volume ls`:
```
DRIVER              VOLUME NAME
local               4372b9211cf90087fcd3bf08973be45b645547859f096fe76fd310ac86fe8974
local               1907314_named
local               1907314_named2
local               d3e096e24676688a3c8a74eaf1822e29bfb160a2df231c7debba6a15dc17f22d
```
The 2 hashes correspond to the 2 anonymous volumes declared in the compose. However, there is one quirk, in that the Supervisor will log `Found unmanaged Volume` for managed anonymous volumes:
```
[debug]   Found unmanaged Volume: d3e096e24676688a3c8a74eaf1822e29bfb160a2df231c7debba6a15dc17f22d
[debug]   Found unmanaged Volume: 4372b9211cf90087fcd3bf08973be45b645547859f096fe76fd310ac86fe8974
```
Perhaps we should change the wording to `Found unmanaged or anonymous Volume`?

Also checked that a release with balena feature labels specified will use binds with the short syntax, for now. In the next PR we can move to using long syntax.

Note that if pushing a docker-compose with invalid long syntax, such as type: volume without target, or type: volume where a separate volume stanza is not included in the docker-compose.yml, compose will error (therefore balena-compose should pick this up too, and the Supervisor shouldn't need to handle it). Even so, I've added the log of `Ignoring invalid compose volume definition` so the Supervisor is super clear about how it's handling various long syntax volume definitions.

Other manual tests include the usual ones:
- Dashboard actions - reboot, purge, shutdown, restart services
- Set & remove a config var
- Move device to another app, move it back
- Updating between multicontainer releases
- Updating between single container releases
- Enable local mode, push a release, trigger a change, disable local mode