### PR TITLE
Do not migrate apps.json if preload v2 to v3 fails

### DIFF
--- a/src/device-state/preload.ts
+++ b/src/device-state/preload.ts
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import { promises as fs } from 'fs';
 
 import { Image, imageFromService } from '../compose/images';
+import { NumericIdentifier } from '../types';
 import * as deviceState from '../device-state';
 import * as config from '../config';
 import * as deviceConfig from '../device-config';
@@ -66,11 +67,7 @@ export async function loadTargetFromFile(appsPath: string): Promise<boolean> {
 		}
 
 		// if apps.json apps are keyed by numeric ids, then convert to v3 target state
-		if (
-			Object.keys(stateFromFile.apps || {}).some(
-				(appId) => !isNaN(parseInt(appId, 10)),
-			)
-		) {
+		if (Object.keys(stateFromFile.apps || {}).some(NumericIdentifier.is)) {
 			stateFromFile = await fromV2AppsJson(stateFromFile as any);
 		}
 

--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -309,8 +309,14 @@ export async function fromV2TargetApps(
 						const appId = parseInt(id, 10);
 						const app = apps[appId];
 
-						// If local mode just use id as uuid
-						const uuid = local ? id : await getUUIDFromAPI(appId);
+						// If local mode or connectivity is not available just use id as uuid
+						const uuid = local
+							? id
+							: await getUUIDFromAPI(appId).catch(() => {
+									throw new Error(
+										'Cannot migrate from v2 apps.json without Internet connectivity. Please use balenaCLI v13.5.1+ for offline preload support.',
+									);
+							  });
 
 						const releases = app.commit
 							? {


### PR DESCRIPTION
Preloading for OS versions with supervisor v13 need to use a newer CLI. The supervisor has a mechanism to migrate apps.json from a v2 apps.json into a v3 apps.json, however it would fail if the device was preloading without connectivity and apps.json would get migrated anyway, meaning the supervisor would not retry the preloading step later.

This PR adds a more clarifying message if this condition happens pointing users to preload with a newer CLI, but it also makes it so the apps.json is not migrated, allowing the preloading step to be retried if the device is rebooted.

This PR also fixes the check for v2 apps.json, which was being triggered before by appUuids starting with a number `12deadbeef`

Closes: #1943
Relates-to: https://github.com/balena-io-modules/balena-preload/pull/273
Change-type: patch
Signed-off-by: Christina Wang <christina@balena.io>