### PR TITLE
Shutdown with locks

### DIFF
--- a/src/compose/composition-steps.ts
+++ b/src/compose/composition-steps.ts
@@ -120,7 +120,7 @@ type Executors<T extends CompositionStepAction> = {
 type LockingFn = (
 	// TODO: Once the entire codebase is typescript, change
 	// this to number
-	app: number | null,
+	app: number | number[] | null,
 	args: BaseCompositionStepArgs,
 	fn: () => Promise<unknown>,
 ) => Promise<unknown>;

--- a/src/device-state.ts
+++ b/src/device-state.ts
@@ -684,24 +684,36 @@ export function reportCurrentState(newState: DeviceReport = {}) {
 	emitAsync('change', undefined);
 }
 
-export async function reboot(force?: boolean, skipLock?: boolean) {
-	await updateLock.abortIfHUPInProgress({ force });
-	await applicationManager.stopAll({ force, skipLock });
-	logger.logSystemMessage('Rebooting', {}, 'Reboot');
-	const $reboot = await dbus.reboot();
-	shuttingDown = true;
-	emitAsync('shutdown', undefined);
-	return await $reboot;
+export interface ShutdownOpts {
+	force?: boolean;
+	reboot?: boolean;
 }
 
-export async function shutdown(force?: boolean, skipLock?: boolean) {
+export async function shutdown({
+	force = false,
+	reboot = false,
+}: ShutdownOpts = {}) {
 	await updateLock.abortIfHUPInProgress({ force });
-	await applicationManager.stopAll({ force, skipLock });
-	logger.logSystemMessage('Shutting down', {}, 'Shutdown');
-	const $shutdown = await dbus.shutdown();
-	shuttingDown = true;
-	emitAsync('shutdown', undefined);
-	return $shutdown;
+	// Get current apps to create locks for
+	const apps = await applicationManager.getCurrentApps();
+	const appIds = Object.keys(apps).map((strId) => parseInt(strId, 10));
+	// Try to create a lock for all the services before shutting down
+	return updateLock.lock(appIds, { force }, async () => {
+		let dbusAction;
+		switch (reboot) {
+			case true:
+				logger.logSystemMessage('Rebooting', {}, 'Reboot');
+				dbusAction = await dbus.reboot();
+				break;
+			case false:
+				logger.logSystemMessage('Shutting down', {}, 'Shutdown');
+				dbusAction = await dbus.shutdown();
+				break;
+		}
+		shuttingDown = true;
+		emitAsync('shutdown', undefined);
+		return dbusAction;
+	});
 }
 
 export async function executeStepAction<T extends PossibleStepTargets>(
@@ -728,13 +740,13 @@ export async function executeStepAction<T extends PossibleStepTargets>(
 				// and if they do, we wouldn't know about it until after
 				// the response has been sent back to the API. Just return
 				// "OK" for this and the below action
-				await reboot(force, skipLock);
+				await shutdown({ force, reboot: true });
 				return {
 					Data: 'OK',
 					Error: null,
 				};
 			case 'shutdown':
-				await shutdown(force, skipLock);
+				await shutdown({ force, reboot: false });
 				return {
 					Data: 'OK',
 					Error: null,

--- a/test/05-device-state.spec.ts
+++ b/test/05-device-state.spec.ts
@@ -548,7 +548,7 @@ describe('device-state', () => {
 			.stub(updateLock, 'abortIfHUPInProgress')
 			.throws(new UpdatesLockedError(testErrMsg));
 
-		await expect(deviceState.reboot())
+		await expect(deviceState.shutdown({ reboot: true }))
 			.to.eventually.be.rejectedWith(testErrMsg)
 			.and.be.an.instanceOf(UpdatesLockedError);
 		await expect(deviceState.shutdown())


### PR DESCRIPTION
The previous logic would shutdown each application before shutting down the device. I believe this was done because if you can't shutdown an application due to locks then you can't shutdown a device so it was a good idea. The problem was that this caused restart policy "unless-stopped" to be triggered incorrectly since the Supervisor was stopping containers..this caused the containers to not be started again on boot.

This PR solves that by just checking for locks. I wrote this PR to be multi-app safe which added more work.

Unit test coverage is pretty good for this part of the codebase. I performed some manual integration tests by adding locks to services then trying to reboot from the dashboard as well as ensuring that containers with `unless-stopped` are not stuck in stopped state after a reboot.