### PR TITLE
Don't use config.get for appId when checking locks in host config PATCH

### DIFF
--- a/test/41-device-api-v1.spec.ts
+++ b/test/41-device-api-v1.spec.ts
@@ -31,10 +31,11 @@ import * as targetStateCache from '../src/device-state/target-state-cache';
 import blink = require('../src/lib/blink');
 import constants = require('../src/lib/constants');
 import * as deviceAPI from '../src/device-api/common';
-
 import { UpdatesLockedError } from '../src/lib/errors';
 import { SchemaTypeKey } from '../src/config/schema-type';
 import log from '../src/lib/supervisor-console';
+import * as applicationManager from '../src/compose/application-manager';
+import App from '../src/compose/app';
 
 describe('SupervisorAPI [V1 Endpoints]', () => {
 	let api: SupervisorAPI;
@@ -937,11 +938,23 @@ describe('SupervisorAPI [V1 Endpoints]', () => {
 			before(() => {
 				configSetStub = stub(config, 'set').callsFake(configSetFakeFn);
 				logWarnStub = stub(log, 'warn');
+				stub(applicationManager, 'getCurrentApps').resolves({
+					'1234567': new App(
+						{
+							appId: 1234567,
+							services: [],
+							volumes: {},
+							networks: {},
+						},
+						false,
+					),
+				});
 			});
 
 			after(() => {
 				configSetStub.restore();
 				logWarnStub.restore();
+				(applicationManager.getCurrentApps as SinonStub).restore();
 			});
 
 			beforeEach(() => {


### PR DESCRIPTION
In a previous PR I added update lock checks to the PATCH /v1/device/host-config route, but this used `config.get('applicationId')` which we should avoid as it reads from `config.json`, and the appId does not update when moving the device between fleets. It's also not multi-app compatible. With changes from https://github.com/balena-os/balena-supervisor/pull/1953, the update lock check in host-config is now multi-app compatible and avoids going through the config module.

Change-type: patch
Signed-off-by: Christina Wang <christina@balena.io>
