### PR TITLE
Do not send name as part of the current state

### DIFF
--- a/src/device-state.ts
+++ b/src/device-state.ts
@@ -481,11 +481,7 @@ export async function setTarget(target: TargetState, localSource?: boolean) {
 
 	globalEventBus.getInstance().emit('targetStateChanged', target);
 
-	const { uuid, apiEndpoint } = await config.getMany([
-		'uuid',
-		'apiEndpoint',
-		'name',
-	]);
+	const { uuid, apiEndpoint } = await config.getMany(['uuid', 'apiEndpoint']);
 
 	if (!uuid || !target[uuid]) {
 		throw new Error(
@@ -625,11 +621,7 @@ export async function getCurrentForReport(
 			{} as { [appUuid: string]: AppState },
 		);
 
-	const { name, uuid, localMode } = await config.getMany([
-		'name',
-		'uuid',
-		'localMode',
-	]);
+	const { uuid, localMode } = await config.getMany(['uuid', 'localMode']);
 
 	if (!uuid) {
 		throw new InternalInconsistencyError('No uuid found for local device');
@@ -649,7 +641,6 @@ export async function getCurrentForReport(
 			{
 				...currentVolatile,
 				...systemInfo,
-				name,
 				apps: appsForReport,
 			},
 			(__, key) => omitFromReport.includes(key),


### PR DESCRIPTION
This fixes a race condition that could occur with the first current
state report, where if the device managed to send the current state
report first, then the device name on the cloud would be set to `local`
(see #1959).

Closes: #1959
Change-type: patch

# How Has This Been Tested?

- Provision a new device with v2.98.33, there is a good chance the name will be set to `local`
- Sync this latest version of the supervisor using `npm run sync`
- SSH into the device, stop the supervisor and remove the database under `/mnt/data/resin-data/balena-supervisor`
- Change the device name on the cloud
- Start sync again, it should not change the device name 