### PR TITLE
Better document mocked-dbus, add missing test methods

### DIFF
--- a/src/lib/dbus.ts
+++ b/src/lib/dbus.ts
@@ -1,15 +1,13 @@
-import * as Bluebird from 'bluebird';
-import * as dbus from 'dbus';
+import { getBus, DBusError } from 'dbus';
+import { promisify } from 'util';
 import { TypedError } from 'typed-error';
 
 import log from './supervisor-console';
 
 export class DbusError extends TypedError {}
 
-const bus = dbus.getBus('system');
-const getInterfaceAsync = Bluebird.promisify(bus.getInterface, {
-	context: bus,
-});
+const bus = getBus('system');
+const getInterfaceAsync = promisify(bus.getInterface.bind(bus));
 
 async function getSystemdInterface() {
 	try {
@@ -19,7 +17,7 @@ async function getSystemdInterface() {
 			'org.freedesktop.systemd1.Manager',
 		);
 	} catch (e) {
-		throw new DbusError(e);
+		throw new DbusError(e as DBusError);
 	}
 }
 
@@ -31,7 +29,7 @@ export async function getLoginManagerInterface() {
 			'org.freedesktop.login1.Manager',
 		);
 	} catch (e) {
-		throw new DbusError(e);
+		throw new DbusError(e as DBusError);
 	}
 }
 
@@ -41,7 +39,7 @@ async function startUnit(unitName: string) {
 	try {
 		systemd.StartUnit(unitName, 'fail');
 	} catch (e) {
-		throw new DbusError(e);
+		throw new DbusError(e as DBusError);
 	}
 }
 
@@ -51,7 +49,7 @@ export async function restartService(serviceName: string) {
 	try {
 		systemd.RestartUnit(`${serviceName}.service`, 'fail');
 	} catch (e) {
-		throw new DbusError(e);
+		throw new DbusError(e as DBusError);
 	}
 }
 
@@ -69,7 +67,7 @@ async function stopUnit(unitName: string) {
 	try {
 		systemd.StopUnit(unitName, 'fail');
 	} catch (e) {
-		throw new DbusError(e);
+		throw new DbusError(e as DBusError);
 	}
 }
 
@@ -86,7 +84,7 @@ export async function enableService(serviceName: string) {
 	try {
 		systemd.EnableUnitFiles([`${serviceName}.service`], false, false);
 	} catch (e) {
-		throw new DbusError(e);
+		throw new DbusError(e as DBusError);
 	}
 }
 
@@ -95,7 +93,7 @@ export async function disableService(serviceName: string) {
 	try {
 		systemd.DisableUnitFiles([`${serviceName}.service`], false);
 	} catch (e) {
-		throw new DbusError(e);
+		throw new DbusError(e as DBusError);
 	}
 }
 

--- a/test/lib/mocked-dbus.ts
+++ b/test/lib/mocked-dbus.ts
@@ -2,33 +2,66 @@ import * as dbus from 'dbus';
 import { DBusError, DBusInterface } from 'dbus';
 import { stub } from 'sinon';
 
+/**
+ * Because lib/dbus invokes dbus.getBus on module import,
+ * getBus needs to be stubbed at the root level due how JS
+ * `require` works. lib/dbus interfaces with the systemd and
+ * logind interfaces, which expose the unit methods below.
+ *
+ * There should be no need to un-stub dbus.getBus at any point
+ * during testing, since we never want to interact with the actual
+ * dbus system socket in the test environment.
+ *
+ * To test interaction with lib/dbus, import lib/dbus into the test suite
+ * and stub the necessary methods, as you would with any other module.
+ */
 stub(dbus, 'getBus').returns({
 	getInterface: (
-		_serviceName: string,
+		serviceName: string,
 		_objectPath: string,
 		_interfaceName: string,
 		interfaceCb: (err: null | DBusError, iface: DBusInterface) => void,
 	) => {
-		interfaceCb(null, {
-			Get: (
-				_unitName: string,
-				_property: string,
-				getCb: (err: null | Error, value: unknown) => void,
-			) => {
-				getCb(null, 'this is the value');
-			},
-			GetUnit: (
-				_unitName: string,
-				getUnitCb: (err: null | Error, unitPath: string) => void,
-			) => {
-				getUnitCb(null, 'this is the unit path');
-			},
-			StartUnit: (_unitName: string) => {
-				// noop
-			},
-			RestartUnit: (_unitName: string, _mode: string) => {
-				// noop
-			},
-		} as any);
+		if (/systemd/.test(serviceName)) {
+			interfaceCb(null, {
+				StartUnit: () => {
+					// noop
+				},
+				RestartUnit: () => {
+					// noop
+				},
+				StopUnit: () => {
+					// noop
+				},
+				EnableUnitFiles: () => {
+					// noop
+				},
+				DisableUnitFiles: () => {
+					// noop
+				},
+				GetUnit: (
+					_unitName: string,
+					getUnitCb: (err: null | Error, unitPath: string) => void,
+				) => {
+					getUnitCb(null, 'this is the unit path');
+				},
+				Get: (
+					_unitName: string,
+					_property: string,
+					getCb: (err: null | Error, value: unknown) => void,
+				) => {
+					getCb(null, 'this is the value');
+				},
+			} as any);
+		} else {
+			interfaceCb(null, {
+				Reboot: () => {
+					// noop
+				},
+				PowerOff: () => {
+					// noop
+				},
+			} as any);
+		}
 	},
-} as any);
+} as dbus.DBusConnection);


### PR DESCRIPTION
~~With this change, dbus is stubbed in isolation and `mock` must be called explicitly to stub dbus methods. The mock-dbus module exposes a set of stubs of methods in `src/lib/dbus.ts` for use during testing.~~

~~Additionally, dbus.getBus instances are now acquired via dependency injection. Previously, on lib/dbus module import, `const bus = dbus.getBus('system')` was called immediately, making isolating the effects of this difficult in the testing environment. The small refactor in lib/dbus functions the same but avoids the import-with-side-effects antipattern.~~

After revisiting the code, the additional overhead for removing imports with side effects from lib/dbus may not be worth it. Instead, I better documented why dbus is stubbed like it is, and added missing methods in the stub (Reboot & PowerOff for example).

This change is needed as part of API test improvements in https://github.com/balena-os/balena-supervisor/pull/1955 (WIP).

Change-type: patch
Signed-off-by: Christina Wang <christina@balena.io>
