### PR TITLE
Add custom DTB support for Variscite Dart DT family

### DIFF
--- a/src/config/backends/extra-uEnv.ts
+++ b/src/config/backends/extra-uEnv.ts
@@ -61,7 +61,8 @@ export class ExtraUEnv extends ConfigBackend {
 				deviceType.endsWith('-nano-emmc') ||
 				deviceType.endsWith('-nano-2gb-devkit') ||
 				deviceType.endsWith('-tx2') ||
-				deviceType.includes('-tx2-nx')) &&
+				deviceType.includes('-tx2-nx') ||
+				/imx8mm?-var-dart/.test(deviceType)) &&
 			(await exists(ExtraUEnv.bootConfigPath))
 		);
 	}

--- a/test/33-extra-uenv-config.spec.ts
+++ b/test/33-extra-uenv-config.spec.ts
@@ -269,4 +269,9 @@ const MATCH_TESTS = [
 	{ type: 'photon-tx2-nx', supported: true },
 	{ type: 'jetson-xavier-nx-devkit', supported: false },
 	{ type: 'photon-xavier-nx', supported: false },
+	{ type: 'imx8m-var-dart', supported: true },
+	{ type: 'imx8mm-var-dart', supported: true },
+	{ type: 'imx8mm-var-dart-nrt', supported: true },
+	{ type: 'imx8mm-var-dart-plt', supported: true },
+	{ type: 'imx6ul-var-dart', supported: false },
 ];


### PR DESCRIPTION
Supports the following slugs:
```
imx8m-var-dart
imx8mm-var-dart
imx8mm-var-dart-nrt
imx8mm-var-dart-plt
```

Closes: #1963
Relates-to: https://github.com/balena-os/balena-variscite-mx8/pull/134
Relates-to: https://github.com/balena-io/open-balena-api/issues/1033
Change-type: patch
Signed-off-by: Christina Wang <christina@balena.io>