### PR TITLE
Use compose long syntax for /lib/firmware and /lib/modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,4 @@ services:
       io.balena.features.balena-api: '1'
       io.balena.features.dbus: '1'
       io.balena.features.balena-socket: '1'
+      io.balena.features.kernel-modules: '1'

--- a/entry.sh
+++ b/entry.sh
@@ -42,6 +42,9 @@ if [ -n "${BALENA_ROOT_CA}" ]; then
 	fi
 fi
 
+# TODO: Remove this symlink and modprobe call when the Supervisor
+# can update itself. At that point, we should run modprobe through
+# the bind mount as we have the kernel-modules docker-compose label.
 # Mount the host kernel module path onto the expected location
 # We need to do this as busybox doesn't support using a custom location
 if [ ! -d /lib/modules ]; then

--- a/src/compose/app.ts
+++ b/src/compose/app.ts
@@ -24,7 +24,6 @@ import * as config from '../config';
 import { checkTruthy, checkString } from '../lib/validation';
 import { ServiceComposeConfig, DeviceMetadata } from './types/service';
 import { ImageInspectInfo } from 'dockerode';
-import { pathExistsOnHost } from '../lib/fs-utils';
 import { getSupervisorMetadata } from '../lib/supervisor-metadata';
 
 export interface AppConstructOpts {
@@ -738,20 +737,11 @@ export class App {
 			},
 		);
 
-		const [
-			opts,
-			supervisorApiHost,
-			hostPathExists,
-			hostnameOnHost,
-		] = await Promise.all([
+		const [opts, supervisorApiHost, hostnameOnHost] = await Promise.all([
 			config.get('extendedEnvOptions'),
 			dockerUtils
 				.getNetworkGateway(constants.supervisorNetworkInterface)
 				.catch(() => '127.0.0.1'),
-			(async () => ({
-				firmware: await pathExistsOnHost('/lib/firmware'),
-				modules: await pathExistsOnHost('/lib/modules'),
-			}))(),
 			(async () =>
 				_.trim(
 					await fs.readFile(
@@ -764,7 +754,6 @@ export class App {
 		const svcOpts = {
 			appName: app.name,
 			supervisorApiHost,
-			hostPathExists,
 			hostnameOnHost,
 			...opts,
 		};

--- a/src/compose/types/service.ts
+++ b/src/compose/types/service.ts
@@ -328,10 +328,6 @@ export interface DeviceMetadata {
 	supervisorApiHost: string;
 	osVersion: string;
 	hostnameOnHost: string;
-	hostPathExists: {
-		modules: boolean;
-		firmware: boolean;
-	};
 }
 
 export interface DockerDevice {

--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -338,13 +338,17 @@ export async function addFeaturesFromLabels(
 		'io.balena.features.dbus': () =>
 			service.config.volumes.push('/run/dbus:/host/run/dbus'),
 		'io.balena.features.kernel-modules': () =>
-			options.hostPathExists.modules
-				? service.config.volumes.push('/lib/modules:/lib/modules')
-				: null,
+			service.config.volumes.push({
+				type: 'bind',
+				source: '/lib/modules',
+				target: '/lib/modules',
+			} as LongBind),
 		'io.balena.features.firmware': () =>
-			options.hostPathExists.firmware
-				? service.config.volumes.push('/lib/firmware:/lib/firmware')
-				: null,
+			service.config.volumes.push({
+				type: 'bind',
+				source: '/lib/firmware',
+				target: '/lib/firmware',
+			} as LongBind),
 		'io.balena.features.balena-socket': () => {
 			service.config.volumes.push({
 				type: 'bind',

--- a/test/data/docker-states/entrypoint/imageInfo.json
+++ b/test/data/docker-states/entrypoint/imageInfo.json
@@ -86,10 +86,6 @@
 	},
 	"appName": "supervisortest",
 	"supervisorApiHost": "172.17.0.1",
-	"hostPathExists": {
-		"firmware": true,
-		"modules": true
-	},
 	"hostnameOnHost": "7dadabd",
 	"uuid": "a7feb967fac7f559ccf2a006a36bcf5d",
 	"listenPort": "48484",

--- a/test/data/docker-states/network-mode-service/imageInfo.json
+++ b/test/data/docker-states/network-mode-service/imageInfo.json
@@ -112,10 +112,6 @@
 	},
 	"appName": "supervisortest",
 	"supervisorApiHost": "172.17.0.1",
-	"hostPathExists": {
-		"firmware": true,
-		"modules": true
-	},
 	"hostnameOnHost": "7dadabd",
 	"uuid": "7dadabd4edec3067948d5952c2f2f26f",
 	"listenPort": "48484",

--- a/test/data/docker-states/simple/imageInfo.json
+++ b/test/data/docker-states/simple/imageInfo.json
@@ -112,10 +112,6 @@
 	},
 	"appName": "supervisortest",
 	"supervisorApiHost": "172.17.0.1",
-	"hostPathExists": {
-		"firmware": true,
-		"modules": true
-	},
 	"hostnameOnHost": "7dadabd",
 	"uuid": "7dadabd4edec3067948d5952c2f2f26f",
 	"listenPort": "48484",

--- a/test/src/compose/service.spec.ts
+++ b/test/src/compose/service.spec.ts
@@ -682,7 +682,7 @@ describe('compose/service', () => {
 				expect(service.config.volumes).to.include.members(['/proc:/proc']);
 			});
 
-			it('should add `/lib/modules` to the container bind mounts when io.balena.features.kernel-modules is used (if the host path exists)', async () => {
+			it('should add `/lib/modules` to the container bind mounts with long syntax when io.balena.features.kernel-modules is used', async () => {
 				const service = await Service.fromComposeObject(
 					{
 						appId: 123456,
@@ -694,41 +694,19 @@ describe('compose/service', () => {
 					},
 					{
 						appName: 'test',
-						hostPathExists: {
-							modules: true,
-						},
 					} as any,
 				);
 
-				expect(service.config.volumes).to.include.members([
-					'/lib/modules:/lib/modules',
-				]);
-			});
-
-			it('should NOT add `/lib/modules` to the container bind mounts when io.balena.features.kernel-modules is used (if the host path does NOT exist)', async () => {
-				const service = await Service.fromComposeObject(
+				expect(service.config.volumes).to.deep.include.members([
 					{
-						appId: 123456,
-						serviceId: 123456,
-						serviceName: 'foobar',
-						labels: {
-							'io.balena.features.kernel-modules': '1',
-						},
+						type: 'bind',
+						source: '/lib/modules',
+						target: '/lib/modules',
 					},
-					{
-						appName: 'test',
-						hostPathExists: {
-							modules: false,
-						},
-					} as any,
-				);
-
-				expect(service.config.volumes).to.not.include.members([
-					'/lib/modules:/lib/modules',
 				]);
 			});
 
-			it('should add `/lib/firmware` to the container bind mounts when io.balena.features.firmware is used (if the host path exists)', async () => {
+			it('should add `/lib/firmware` to the container bind mounts with long syntax when io.balena.features.firmware is used', async () => {
 				const service = await Service.fromComposeObject(
 					{
 						appId: 123456,
@@ -740,37 +718,15 @@ describe('compose/service', () => {
 					},
 					{
 						appName: 'test',
-						hostPathExists: {
-							firmware: true,
-						},
 					} as any,
 				);
 
-				expect(service.config.volumes).to.include.members([
-					'/lib/firmware:/lib/firmware',
-				]);
-			});
-
-			it('should NOT add `/lib/firmware` to the container bind mounts when io.balena.features.firmware is used (if the host path does NOT exist)', async () => {
-				const service = await Service.fromComposeObject(
+				expect(service.config.volumes).to.deep.include.members([
 					{
-						appId: 123456,
-						serviceId: 123456,
-						serviceName: 'foobar',
-						labels: {
-							'io.balena.features.firmware': '1',
-						},
+						type: 'bind',
+						source: '/lib/firmware',
+						target: '/lib/firmware',
 					},
-					{
-						appName: 'test',
-						hostPathExists: {
-							firmware: false,
-						},
-					} as any,
-				);
-
-				expect(service.config.volumes).to.not.include.members([
-					'/lib/firmware:/lib/firmware',
 				]);
 			});
 		});


### PR DESCRIPTION
As /lib/firmware and /lib/modules are always expected to be in the host
filesystem, using long syntax ensures that the Supervisor container
cannot start on an invalid host. (Long syntax volumes error when the host
path does not exist, whereas short syntax volumes create the host path.)

Change-type: major
Closes: #1965
Signed-off-by: Christina Wang <christina@balena.io>

This change is major, because when user applications move to this Supervisor, any containers with the kernel-modules or firmware docker-compose labels will be restarted by the Supervisor due to the short -> long syntax bind migration.