### PR TITLE
Read hostname from config.json with container /etc/hostname as backup

### DIFF
--- a/src/compose/app.ts
+++ b/src/compose/app.ts
@@ -1,6 +1,5 @@
 import * as _ from 'lodash';
 import { promises as fs } from 'fs';
-import * as path from 'path';
 
 import Network from './network';
 import Volume from './volume';
@@ -742,7 +741,7 @@ export class App {
 			opts,
 			supervisorApiHost,
 			hostPathExists,
-			hostnameOnHost,
+			hostname,
 		] = await Promise.all([
 			config.get('extendedEnvOptions'),
 			dockerUtils
@@ -752,20 +751,17 @@ export class App {
 				firmware: await pathExistsOnHost('/lib/firmware'),
 				modules: await pathExistsOnHost('/lib/modules'),
 			}))(),
-			(async () =>
-				_.trim(
-					await fs.readFile(
-						path.join(constants.rootMountPoint, '/etc/hostname'),
-						'utf8',
-					),
-				))(),
+			(
+				(await config.get('hostname')) ??
+				(await fs.readFile('/etc/hostname', 'utf-8'))
+			).trim(),
 		]);
 
 		const svcOpts = {
 			appName: app.name,
 			supervisorApiHost,
 			hostPathExists,
-			hostnameOnHost,
+			hostname,
 			...opts,
 		};
 

--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -300,7 +300,7 @@ export class Service {
 
 		// Any other special case handling
 		if (config.networkMode === 'host' && !config.hostname) {
-			config.hostname = options.hostnameOnHost;
+			config.hostname = options.hostname;
 		}
 		config.restart = ComposeUtils.createRestartPolicy(config.restart);
 		config.command = ComposeUtils.getCommand(config.command, options.imageInfo);

--- a/src/compose/types/service.ts
+++ b/src/compose/types/service.ts
@@ -327,7 +327,7 @@ export interface DeviceMetadata {
 	apiSecret: string;
 	supervisorApiHost: string;
 	osVersion: string;
-	hostnameOnHost: string;
+	hostname: string;
 	hostPathExists: {
 		modules: boolean;
 		firmware: boolean;

--- a/test/data/docker-states/entrypoint/imageInfo.json
+++ b/test/data/docker-states/entrypoint/imageInfo.json
@@ -90,7 +90,7 @@
 		"firmware": true,
 		"modules": true
 	},
-	"hostnameOnHost": "7dadabd",
+	"hostname": "7dadabd",
 	"uuid": "a7feb967fac7f559ccf2a006a36bcf5d",
 	"listenPort": "48484",
 	"name": "Office",

--- a/test/data/docker-states/network-mode-service/imageInfo.json
+++ b/test/data/docker-states/network-mode-service/imageInfo.json
@@ -116,7 +116,7 @@
 		"firmware": true,
 		"modules": true
 	},
-	"hostnameOnHost": "7dadabd",
+	"hostname": "7dadabd",
 	"uuid": "7dadabd4edec3067948d5952c2f2f26f",
 	"listenPort": "48484",
 	"name": "Office",

--- a/test/data/docker-states/simple/imageInfo.json
+++ b/test/data/docker-states/simple/imageInfo.json
@@ -116,7 +116,7 @@
 		"firmware": true,
 		"modules": true
 	},
-	"hostnameOnHost": "7dadabd",
+	"hostname": "7dadabd",
 	"uuid": "7dadabd4edec3067948d5952c2f2f26f",
 	"listenPort": "48484",
 	"name": "Office",


### PR DESCRIPTION
We don't need to read the host's hostname through /mnt/root/etc/hostname,
because the hostname is written to config.json on a change. When the hostname
has never changed, it won't be found in config.json, so we can default to
the Supervisor container's /etc/hostname as it will match the host's
/etc/hostname, the network mode being `host`.

This is a step away from reliance on the `/mnt/root` bind mount, and can be used until https://github.com/balena-os/balena-supervisor/issues/1969.

Closes: #1968
Change-type: patch
Signed-off-by: Christina Wang <christina@balena.io>