### PR TITLE
Wait for Stopping services to stop before target apply success

### DIFF
--- a/src/compose/app.ts
+++ b/src/compose/app.ts
@@ -361,6 +361,18 @@ export class App {
 		};
 
 		/**
+		 * Checks if Supervisor should keep the state loop alive while waiting on a service to stop
+		 * @param serviceCurrent
+		 * @param serviceTarget
+		 */
+		const shouldWaitForStop = (serviceCurrent: Service) => {
+			return (
+				serviceCurrent.config.running === true &&
+				serviceCurrent.status === 'Stopping'
+			);
+		};
+
+		/**
 		 * Filter all the services which should be updated due to run state change, or config mismatch.
 		 */
 		const toBeUpdated = maybeUpdate
@@ -372,7 +384,8 @@ export class App {
 				({ current: c, target: t }) =>
 					!isEqualExceptForRunningState(c, t) ||
 					shouldBeStarted(c, t) ||
-					shouldBeStopped(c, t),
+					shouldBeStopped(c, t) ||
+					shouldWaitForStop(c),
 			);
 
 		return {

--- a/test/src/compose/app.spec.ts
+++ b/test/src/compose/app.spec.ts
@@ -657,6 +657,23 @@ describe('compose/app', () => {
 			expectNoStep('kill', steps);
 		});
 
+		it('should emit a noop while waiting on a stopping service', async () => {
+			const current = createApp({
+				services: [
+					await createService(
+						{ serviceName: 'main', running: true },
+						{ state: { status: 'Stopping' } },
+					),
+				],
+			});
+			const target = createApp({
+				services: [await createService({ serviceName: 'main', running: true })],
+			});
+
+			const steps = current.nextStepsForAppUpdate(defaultContext, target);
+			expectSteps('noop', steps);
+		});
+
 		it('should remove a dead container that is still referenced in the target state', async () => {
 			const current = createApp({
 				services: [


### PR DESCRIPTION
This mitigates an edge case bug introduced in v13.1.3 where services that
are slow to exit may get stuck in a state of Downloaded if a service var is
changed then reverted rapidly (or any other condition in which services are restarted by the state funnel rapidly). More detailed description in linked issue.

Change-type: patch
Closes: #1991
Signed-off-by: Christina Wang <christina@balena.io>

### How Has This Been Tested?

- Ran manual tests in listed in my [integration test list](https://warm-climb-55d.notion.site/Automated-Supervisor-integration-tests-7238e6112b9f4e0a80455233e1946e2b)
- Checked that PR mitigated conditions described in issue 1991

Linking this to #1898 for regression testing.