### PR TITLE
Allow most printable ASCII chars for service label key

### DIFF
--- a/src/types/basic.ts
+++ b/src/types/basic.ts
@@ -109,9 +109,11 @@ export type VariableName = t.TypeOf<typeof VariableName>;
 
 /**
  * Valid label names are between 0 and 255 characters
- * and match /^[a-zA-Z][a-zA-Z0-9\.\-]*$/
+ * and each character is any printable ASCII character except space (0x20),
+ * double and single quotes ( " 0x22,  ' 0x27) and backtick ( ` 0x60). Rationale
+ * is to accept a character unless likely not useful and error prone.
  */
-const LABEL_NAME_REGEX = /^[a-zA-Z][a-zA-Z0-9\.\-]*$/;
+const LABEL_NAME_REGEX = /^[!#-&(-_a-~]+$/;
 
 export const LabelName = new t.Type<string, string>(
 	'LabelName',
@@ -125,7 +127,7 @@ export const LabelName = new t.Type<string, string>(
 					: t.failure(
 							s,
 							c,
-							"needs to start with a letter and may only contain alphanumeric characters plus '-' and '.'",
+							'may contain printable ASCII characters except space, single/double quotes and backtick',
 					  ),
 			),
 		),

--- a/test/unit/lib/validation.spec.ts
+++ b/test/unit/lib/validation.spec.ts
@@ -299,7 +299,13 @@ describe('validation', () => {
 									image_id: 34,
 									image: 'foo',
 									environment: { MY_SERVICE_ENV_VAR: '123' },
-									labels: { 'io.balena.features.supervisor-api': 'true' },
+									labels: {
+										'io.balena.features.supervisor-api': 'true',
+										'caddy.@match.path': '/sourcepath /sourcepath/*',
+										'traefik.http.routers.router0.tls.domains[0].main':
+											'foobar',
+										_not_first_alpha: '1',
+									},
 									running: false,
 								},
 							},
@@ -324,7 +330,13 @@ describe('validation', () => {
 									image_id: 34,
 									image: 'foo',
 									environment: { MY_SERVICE_ENV_VAR: '123' },
-									labels: { 'io.balena.features.supervisor-api': 'true' },
+									labels: {
+										'io.balena.features.supervisor-api': 'true',
+										'caddy.@match.path': '/sourcepath /sourcepath/*',
+										'traefik.http.routers.router0.tls.domains[0].main':
+											'foobar',
+										_not_first_alpha: '1',
+									},
 									running: false,
 								},
 							},
@@ -381,7 +393,7 @@ describe('validation', () => {
 											image_id: 34,
 											image: 'foo',
 											environment: {},
-											labels: { ' not a valid #name': 'label value' },
+											labels: { ' not a valid "name': 'label value' },
 										},
 									},
 									volumes: {},


### PR DESCRIPTION
# Description

Updated the regex for valid characters for a service label to allow printable ASCII chars except space, double/single quotes, and backtick. These extended characters support apps like Traefik and caddy-docker-proxy. Characters still not supported likely are not useful as label keys and error prone.

Fixes #1949

# Type of change

patch

# How Has This Been Tested?

Updated `06-validation.spec.ts`. Also tested by POSTing all valid chars to `/v2/local/target-state`.
