### PR TITLE
Add custom DTB support for imx8mm-var-som

### DIFF
--- a/src/config/backends/extra-uEnv.ts
+++ b/src/config/backends/extra-uEnv.ts
@@ -62,6 +62,7 @@ export class ExtraUEnv extends ConfigBackend {
 				deviceType.endsWith('-nano-2gb-devkit') ||
 				deviceType.endsWith('-tx2') ||
 				deviceType.includes('-tx2-nx') ||
+				/imx8mm-var-som/.test(deviceType) ||
 				/imx8mm?-var-dart/.test(deviceType)) &&
 			(await exists(ExtraUEnv.bootConfigPath))
 		);

--- a/test/legacy/33-extra-uenv-config.spec.ts
+++ b/test/legacy/33-extra-uenv-config.spec.ts
@@ -273,5 +273,7 @@ const MATCH_TESTS = [
 	{ type: 'imx8mm-var-dart', supported: true },
 	{ type: 'imx8mm-var-dart-nrt', supported: true },
 	{ type: 'imx8mm-var-dart-plt', supported: true },
+	{ type: 'imx8mm-var-som', supported: true },
+	{ type: 'imx8m-var-som', supported: false },
 	{ type: 'imx6ul-var-dart', supported: false },
 ];


### PR DESCRIPTION
This adds support for custom device-trees for the upcoming imx8mm-var-som devkit.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>