### PR TITLE
Update balena-register-device to 8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@types/tmp": "^0.1.0",
         "@types/webpack": "^4.41.21",
         "@types/yargs": "^15.0.12",
-        "balena-register-device": "^7.2.0",
+        "balena-register-device": "^8.0.0",
         "blinking": "0.0.5",
         "bluebird": "^3.7.2",
         "chai": "^4.3.4",
@@ -2624,15 +2624,15 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "node_modules/balena-register-device": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/balena-register-device/-/balena-register-device-7.2.0.tgz",
-      "integrity": "sha512-Uo8iceob2Zg8gBedZKzSZWTyr5XoDkUN+2oSyyuKVuhZYcZS623Lsj/+I8QdJQutlObgVHjD2k3mM1Pa6loFxA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/balena-register-device/-/balena-register-device-8.0.0.tgz",
+      "integrity": "sha512-0XFldjx5WjVSBwrMl59ITZHvwGY5Xdfs2K8S/e0EfYxqF6ZjVF5kXUtvQnU7LVrU/7JhYyruQEuuVbi7FboqvA==",
       "dev": true,
       "dependencies": {
         "@types/uuid": "^8.3.0",
         "tslib": "^2.2.0",
         "typed-error": "^3.2.1",
-        "uuid": "^8.3.2"
+        "uuid": "^9.0.0"
       },
       "peerDependencies": {
         "balena-request": "^11.0.0"
@@ -2645,9 +2645,9 @@
       "dev": true
     },
     "node_modules/balena-register-device/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -18993,15 +18993,15 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "balena-register-device": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/balena-register-device/-/balena-register-device-7.2.0.tgz",
-      "integrity": "sha512-Uo8iceob2Zg8gBedZKzSZWTyr5XoDkUN+2oSyyuKVuhZYcZS623Lsj/+I8QdJQutlObgVHjD2k3mM1Pa6loFxA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/balena-register-device/-/balena-register-device-8.0.0.tgz",
+      "integrity": "sha512-0XFldjx5WjVSBwrMl59ITZHvwGY5Xdfs2K8S/e0EfYxqF6ZjVF5kXUtvQnU7LVrU/7JhYyruQEuuVbi7FboqvA==",
       "dev": true,
       "requires": {
         "@types/uuid": "^8.3.0",
         "tslib": "^2.2.0",
         "typed-error": "^3.2.1",
-        "uuid": "^8.3.2"
+        "uuid": "^9.0.0"
       },
       "dependencies": {
         "tslib": {
@@ -19011,9 +19011,9 @@
           "dev": true
         },
         "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@types/tmp": "^0.1.0",
     "@types/webpack": "^4.41.21",
     "@types/yargs": "^15.0.12",
-    "balena-register-device": "^7.2.0",
+    "balena-register-device": "^8.0.0",
     "blinking": "0.0.5",
     "bluebird": "^3.7.2",
     "chai": "^4.3.4",


### PR DESCRIPTION
Once we bump to node v16 this will start using the native `crypto.randomUUID()`.
I hope that at that point the number of uuid clashes we observe will get reduced.

Update balena-register-device from 7.2.0 to 8.0.0

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

*If this is a regression, consider adding it to #1898!*

# Description

Please include a summary of the change and which issue was fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Type of change

Include at least one commit in your PR that marks the change-type. This can be either specified through a Change-type footer, or by adding the change-type as a prefix to the commit, i.e. minor: Add some new feature. This is so the PR can be automatically versioned and a changelog generated for it by using versionist. Check out [semver](https://semver.org/) for a detailed explanation of the different possible change-type values.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
