### PR TITLE
Add support for variable substitution in service configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@balena/happy-eyeballs": "0.0.6",
+        "@balena/variable-substitution": "github:balena-io-modules/balena-variable-substitution#initial",
         "dbus": "^1.0.7",
         "mdns-resolver": "^1.0.0",
         "semver": "^7.3.2",
@@ -904,6 +905,17 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@balena/variable-substitution": {
+      "version": "0.0.0",
+      "resolved": "git+ssh://git@github.com/balena-io-modules/balena-variable-substitution.git#c19ddcda9bf5d9a00b0856919091e1e032d3e3ff",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "typed-error": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -14872,7 +14884,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/typed-error/-/typed-error-3.2.1.tgz",
       "integrity": "sha512-XlUv4JMrT2dpN0c4Vm3lOm88ga21Z6pNJUmjejRz/mkh6sdBtkMwyRf4fF+yhRGZgfgWam31Lkxu11GINKiBTQ==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0",
         "npm": ">=3.0.0"
@@ -16965,6 +16976,13 @@
           "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
           "dev": true
         }
+      }
+    },
+    "@balena/variable-substitution": {
+      "version": "git+ssh://git@github.com/balena-io-modules/balena-variable-substitution.git#c19ddcda9bf5d9a00b0856919091e1e032d3e3ff",
+      "from": "@balena/variable-substitution@git+https://github.com/balena-io-modules/balena-variable-substitution.git#initial",
+      "requires": {
+        "typed-error": "^3.2.1"
       }
     },
     "@dabh/diagnostics": {
@@ -28231,8 +28249,7 @@
     "typed-error": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/typed-error/-/typed-error-3.2.1.tgz",
-      "integrity": "sha512-XlUv4JMrT2dpN0c4Vm3lOm88ga21Z6pNJUmjejRz/mkh6sdBtkMwyRf4fF+yhRGZgfgWam31Lkxu11GINKiBTQ==",
-      "dev": true
+      "integrity": "sha512-XlUv4JMrT2dpN0c4Vm3lOm88ga21Z6pNJUmjejRz/mkh6sdBtkMwyRf4fF+yhRGZgfgWam31Lkxu11GINKiBTQ=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "private": true,
   "dependencies": {
     "@balena/happy-eyeballs": "0.0.6",
+    "@balena/variable-substitution": "github:balena-io-modules/balena-variable-substitution#initial",
     "dbus": "^1.0.7",
     "mdns-resolver": "^1.0.0",
     "semver": "^7.3.2",


### PR DESCRIPTION
This adds the ability for the Supervisor to interpolate variables in service configuration with values specified remotely via fleet, device and/or service environment variables.

Change-type: minor
