### PR TITLE
Fix migrations hardcode to work with knex 0.95.15 

### DIFF
--- a/build-utils/hardcode-migrations.js
+++ b/build-utils/hardcode-migrations.js
@@ -2,10 +2,12 @@
 // This hack makes the migrations directory a constant so that at least we can use webpack contexts for the
 // require.
 module.exports = function (source) {
-	return source
-		.toString()
-		.replace(
-			'path.join(absoluteDir, migration.file)',
-			`'./migrations/'+migration.file`,
-		);
+	return (
+		source
+			.toString()
+			// IMPORTANT: this is known to work with knex v0.95.15. It will most likely break
+			// if knex is upgraded. This is really a hack and should be replaced by a more sustainable
+			// webpack configuration.
+			.replace('importFile(_path)', "require('./migrations/'+migration.file)")
+	);
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -103,7 +103,10 @@ module.exports = function (env) {
 				{
 					include: [
 						new RegExp(
-							_.escapeRegExp(path.join('knex', 'lib', 'migrate', 'sources')),
+							_.escapeRegExp(
+								// this is the path as of knex@0.95.15
+								path.join('knex', 'lib', 'migrations', 'migrate', 'sources'),
+							),
 						),
 					],
 					use: require.resolve('./build-utils/hardcode-migrations'),


### PR DESCRIPTION
The latest upgrade of knex broke the webpack loader that hardcodes the
migration paths in the built code, that cause supervisors 14.2.3 to
14.2.5 (inclusive) to break anytime migrations needed to be ran (see linked issue).

This commit fixes the loader to work with the included knex version.

Relates-to: #2032
Change-type: patch