### PR TITLE
config/backends: Add Jetson AGX Orin Devkit to the list of DTs that support configurable device-trees

### DIFF
--- a/src/config/backends/extra-uEnv.ts
+++ b/src/config/backends/extra-uEnv.ts
@@ -62,6 +62,7 @@ export class ExtraUEnv extends ConfigBackend {
 				deviceType.endsWith('-nano-2gb-devkit') ||
 				deviceType.endsWith('-tx2') ||
 				deviceType.includes('-tx2-nx') ||
+				deviceType.includes('-agx-orin-') ||
 				/imx8mm-var-som/.test(deviceType) ||
 				/imx8mm?-var-dart/.test(deviceType)) &&
 			(await exists(ExtraUEnv.bootConfigPath))

--- a/test/legacy/33-extra-uenv-config.spec.ts
+++ b/test/legacy/33-extra-uenv-config.spec.ts
@@ -267,6 +267,8 @@ const MATCH_TESTS = [
 	{ type: 'jetson-tx2-nx-devkit', supported: true },
 	{ type: 'photon-tx2-nx', supported: true },
 	{ type: 'jetson-xavier-nx-devkit', supported: false },
+	{ type: 'jetson-agx-orin-devkit', supported: true },
+	{ type: 'jetson-agx-orin', supported: false },
 	{ type: 'photon-xavier-nx', supported: false },
 	{ type: 'imx8m-var-dart', supported: true },
 	{ type: 'imx8mm-var-dart', supported: true },


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Connects-to: https://github.com/balena-os/balena-jetson/issues/389

