### PR TITLE
Update apt repositories before installing dbus

### DIFF
--- a/build-utils/install-dbus.sh
+++ b/build-utils/install-dbus.sh
@@ -10,6 +10,7 @@ if command -v apt > /dev/null; then
         exit 0
     else
         echo "Installing $DEBIAN..."
+        sudo apt-get update
         sudo apt-get install $DEBIAN
     fi
 elif command -v brew > /dev/null; then


### PR DESCRIPTION
GitHub actions are erroring due to the package not being found; Updating the repository listings shoud fix this.

Change-type: patch
Signed-off-by: Christina Ying Wang <christina@balena.io>