### PR TITLE
Allow local target state to be applied in unmanaged mode

### DIFF
--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -32,7 +32,7 @@ type ContractRequirements = {
 
 const contractRequirementVersions: ContractRequirements = {};
 
-export function intialiseContractRequirements(opts: {
+export function initializeContractRequirements(opts: {
 	supervisorVersion: string;
 	deviceType: string;
 	l4tVersion?: string;

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -8,7 +8,7 @@ import * as v1 from './device-api/v1';
 import * as v2 from './device-api/v2';
 import logMonitor from './logging/monitor';
 
-import { intialiseContractRequirements } from './lib/contracts';
+import { initializeContractRequirements } from './lib/contracts';
 import { normaliseLegacyDatabase } from './lib/legacy';
 import * as osRelease from './lib/os-release';
 import log from './lib/supervisor-console';
@@ -42,7 +42,7 @@ export class Supervisor {
 
 		const conf = await config.getMany(startupConfigFields);
 
-		intialiseContractRequirements({
+		initializeContractRequirements({
 			supervisorVersion: version,
 			deviceType: await config.get('deviceType'),
 			l4tVersion: await osRelease.getL4tVersion(),

--- a/test/integration/device-state.spec.ts
+++ b/test/integration/device-state.spec.ts
@@ -8,7 +8,7 @@ import * as deviceState from '~/src/device-state';
 import { appsJsonBackup, loadTargetFromFile } from '~/src/device-state/preload';
 import { TargetState } from '~/src/types';
 import { promises as fs } from 'fs';
-import { intialiseContractRequirements } from '~/lib/contracts';
+import { initializeContractRequirements } from '~/lib/contracts';
 
 import { testfs } from 'mocha-pod';
 import { createDockerImage } from '~/test-lib/docker-helper';
@@ -21,7 +21,7 @@ describe('device-state', () => {
 
 		// Set the device uuid
 		await config.set({ uuid: 'local' });
-		intialiseContractRequirements({
+		initializeContractRequirements({
 			supervisorVersion: '11.0.0',
 			deviceType: 'intel-nuc',
 		});

--- a/test/integration/lib/contracts.spec.ts
+++ b/test/integration/lib/contracts.spec.ts
@@ -5,7 +5,7 @@ import * as semver from 'semver';
 import * as constants from '~/lib/constants';
 import {
 	containerContractsFulfilled,
-	intialiseContractRequirements,
+	initializeContractRequirements,
 	validateContract,
 } from '~/lib/contracts';
 import * as osRelease from '~/lib/os-release';
@@ -14,7 +14,7 @@ import * as fsUtils from '~/lib/fs-utils';
 
 describe('lib/contracts', () => {
 	before(() => {
-		intialiseContractRequirements({
+		initializeContractRequirements({
 			supervisorVersion,
 			deviceType: 'intel-nuc',
 			l4tVersion: '32.2',
@@ -436,7 +436,7 @@ describe('L4T version detection', () => {
 				execStub.restore();
 			}
 			seedExec(version);
-			intialiseContractRequirements({
+			initializeContractRequirements({
 				supervisorVersion,
 				deviceType: 'intel-nuc',
 				l4tVersion: await osRelease.getL4tVersion(),


### PR DESCRIPTION
Allow local target state to be applied in unmanaged mode

An unmanaged Supervisor will not have a balenaApi defined, so any attempts to POST /v2/local/target-state will cause the Supervisor to crash loop. This fix allows for the Supervisor to apply local target state, which is useful for integration testing.

This was introduced in Supervisors v13+.

Change-type: patch
Signed-off-by: Christina Ying Wang <christina@balena.io>