### PR TITLE
Set up dummy Supervisor image for integration tests

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,6 +2,7 @@ version: '2.3'
 
 services:
   dbus-services:
+    stop_grace_period: 3s
     environment:
       DEVELOPMENT: 1
     volumes:
@@ -9,6 +10,7 @@ services:
       - './test/lib/dbus/login.ts:/usr/src/app/login.ts'
 
   sut:
+    stop_grace_period: 3s
     command: sleep infinity
     volumes:
       - './.mochapodrc.yml:/usr/src/app/.mochapodrc.yml'

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,6 +12,7 @@ services:
     command: [ '/wait-for-it.sh', '--', '/usr/src/app/entry.sh' ]
     # Use bridge networking for the tests
     network_mode: 'bridge'
+    stop_grace_period: 3s
     networks:
       - default
     environment:
@@ -34,6 +35,7 @@ services:
 
   dbus:
     image: balenablocks/dbus
+    stop_grace_period: 3s
     environment:
       DBUS_CONFIG: session.conf
       DBUS_ADDRESS: unix:path=/run/dbus/system_bus_socket
@@ -44,6 +46,7 @@ services:
   # requests
   dbus-services:
     build: ./test/lib/dbus
+    stop_grace_period: 3s
     depends_on:
       - dbus
     volumes:
@@ -54,6 +57,7 @@ services:
   docker:
     image: docker:dind
     privileged: true
+    stop_grace_period: 3s
     environment:
       DOCKER_TLS_CERTDIR: ''
     command: --tls=false # --debug
@@ -76,6 +80,7 @@ services:
         'run',
         'test:integration'
       ]
+    stop_grace_period: 3s
     depends_on:
       - balena-supervisor
       - docker
@@ -92,6 +97,7 @@ services:
       CONFIG_MOUNT_POINT: /mnt/root/mnt/boot/config.json
       # Read by constants to setup `bootMountpoint`
       BOOT_MOUNTPOINT: /mnt/boot
+      INTEGRATION: true
     # Set required mounts as tmpfs or volumes here
     # if specific files need to be backed up between tests,
     # make sure to add them to the `testfs` configuration under

--- a/test/integration/compose/application-manager.spec.ts
+++ b/test/integration/compose/application-manager.spec.ts
@@ -14,6 +14,7 @@ import { ServiceComposeConfig } from '~/src/compose/types/service';
 import Volume from '~/src/compose/volume';
 import { InstancedAppState } from '~/src/types/state';
 import * as config from '~/src/config';
+import { cleanupDocker } from '~/test-lib/docker-helper';
 
 const DEFAULT_NETWORK = Network.fromComposeObject('default', 1, 'appuuid', {});
 
@@ -194,15 +195,7 @@ describe('compose/application-manager', () => {
 	});
 
 	afterEach(async () => {
-		// Delete any created networks
-		const docker = new Docker();
-		const allNetworks = await docker.listNetworks();
-		await Promise.all(
-			allNetworks
-				// exclude docker default networks from the cleanup
-				.filter(({ Name }) => !['bridge', 'host', 'none'].includes(Name))
-				.map(({ Name }) => docker.getNetwork(Name).remove()),
-		);
+		await cleanupDocker();
 	});
 
 	// TODO: we don't test application manager initialization as it sets up a bunch of timers

--- a/test/integration/compose/images.spec.ts
+++ b/test/integration/compose/images.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import * as imageManager from '~/src/compose/images';
 import { createImage, withMockerode } from '~/test-lib/mockerode';
-import { createDockerImage } from '~/test-lib/docker-helper';
+import { cleanupDocker, createDockerImage } from '~/test-lib/docker-helper';
 
 import * as Docker from 'dockerode';
 import * as db from '~/src/db';
@@ -38,7 +38,7 @@ describe('compose/images', () => {
 	});
 
 	after(async () => {
-		await docker.pruneImages({ filters: { dangling: { false: true } } });
+		await cleanupDocker({ docker });
 	});
 
 	it('finds image by matching digest on the database', async () => {

--- a/test/integration/compose/network.spec.ts
+++ b/test/integration/compose/network.spec.ts
@@ -4,18 +4,12 @@ import { Network } from '~/src/compose/network';
 import { createNetwork, withMockerode } from '~/test-lib/mockerode';
 
 import * as Docker from 'dockerode';
+import { cleanupDocker } from '~/test-lib/docker-helper';
 
 describe('compose/network: integration tests', () => {
 	const docker = new Docker();
 	after(async () => {
-		const allNetworks = await docker.listNetworks();
-
-		// Delete any remaining networks
-		await Promise.all(
-			allNetworks
-				.filter(({ Name }) => !['bridge', 'host', 'none'].includes(Name)) // exclude docker default network from the cleanup
-				.map(({ Name }) => docker.getNetwork(Name).remove()),
-		);
+		await cleanupDocker({ docker });
 	});
 
 	describe('creating and removing networks', () => {

--- a/test/integration/compose/volume-manager.spec.ts
+++ b/test/integration/compose/volume-manager.spec.ts
@@ -3,16 +3,14 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as volumeManager from '~/src/compose/volume-manager';
 import Volume from '~/src/compose/volume';
-import { createDockerImage } from '~/test-lib/docker-helper';
+import { cleanupDocker, createDockerImage } from '~/test-lib/docker-helper';
 
 import * as Docker from 'dockerode';
 
 describe('compose/volume-manager', () => {
 	const docker = new Docker();
 	after(async () => {
-		await docker.pruneContainers();
-		await docker.pruneVolumes();
-		await docker.pruneImages({ filters: { dangling: { false: true } } });
+		await cleanupDocker({ docker });
 	});
 
 	describe('Retrieving volumes from the engine', () => {

--- a/test/integration/compose/volume.spec.ts
+++ b/test/integration/compose/volume.spec.ts
@@ -7,6 +7,7 @@ import * as logger from '~/src/logger';
 import * as Docker from 'dockerode';
 
 import { createVolume, withMockerode } from '~/test-lib/mockerode';
+import { cleanupDocker } from '~/test-lib/docker-helper';
 
 describe('compose/volume: integration tests', () => {
 	const docker = new Docker();
@@ -23,10 +24,7 @@ describe('compose/volume: integration tests', () => {
 		});
 
 		after(async () => {
-			const { Volumes: allVolumes } = await docker.listVolumes();
-			await Promise.all(
-				allVolumes.map(({ Name }) => docker.getVolume(Name).remove()),
-			);
+			await cleanupDocker({ docker });
 			(logger.logSystemEvent as SinonStub).restore();
 		});
 

--- a/test/integration/device-state.spec.ts
+++ b/test/integration/device-state.spec.ts
@@ -11,7 +11,7 @@ import { promises as fs } from 'fs';
 import { initializeContractRequirements } from '~/lib/contracts';
 
 import { testfs } from 'mocha-pod';
-import { createDockerImage } from '~/test-lib/docker-helper';
+import { cleanupDocker, createDockerImage } from '~/test-lib/docker-helper';
 import * as Docker from 'dockerode';
 
 describe('device-state', () => {
@@ -28,7 +28,7 @@ describe('device-state', () => {
 	});
 
 	after(async () => {
-		await docker.pruneImages({ filters: { dangling: { false: true } } });
+		await cleanupDocker({ docker });
 	});
 
 	it('loads a target state from an apps.json file and saves it as target state, then returns it', async () => {

--- a/test/integration/lib/docker-utils.spec.ts
+++ b/test/integration/lib/docker-utils.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { stub } from 'sinon';
 
 import * as dockerUtils from '~/lib/docker-utils';
-import { createDockerImage } from '~/test-lib/docker-helper';
+import { cleanupDocker, createDockerImage } from '~/test-lib/docker-helper';
 import * as Docker from 'dockerode';
 
 describe('lib/docker-utils', () => {
@@ -28,14 +28,7 @@ describe('lib/docker-utils', () => {
 		});
 
 		after(async () => {
-			const allNetworks = await docker.listNetworks();
-
-			// Delete any remaining networks
-			await Promise.all(
-				allNetworks
-					.filter(({ Name }) => !['bridge', 'host', 'none'].includes(Name)) // exclude docker default network from the cleanup
-					.map(({ Name }) => docker.getNetwork(Name).remove()),
-			);
+			await cleanupDocker({ docker });
 		});
 
 		// test using existing data...
@@ -59,7 +52,7 @@ describe('lib/docker-utils', () => {
 		});
 
 		after(async () => {
-			await docker.pruneImages({ filters: { dangling: { false: true } } });
+			await cleanupDocker({ docker });
 		});
 
 		// test using existing data...

--- a/test/lib/docker-helper.ts
+++ b/test/lib/docker-helper.ts
@@ -1,7 +1,12 @@
 import * as Docker from 'dockerode';
 import * as tar from 'tar-stream';
-
+import { setTimeout } from 'timers/promises';
 import { strict as assert } from 'assert';
+
+import { supervisorImage } from '~/lib/constants';
+import { isStatusError } from '~/lib/errors';
+
+export const BASE_IMAGE = 'alpine:latest';
 
 // Creates an image from scratch with just some labels
 export async function createDockerImage(
@@ -41,3 +46,77 @@ export async function createDockerImage(
 		});
 	});
 }
+
+/**
+ * In integration test env, the Supervisor container expects an image
+ * tagged balena/$ARCH-supervisor to be able to apply target state.
+ * We can't access the SV container for stubbing the method that
+ * checks the presence of this image, so a minimal image should
+ * be pulled and tagged.
+ */
+export const setupSupervisorImage = async () => {
+	const docker = new Docker();
+	await docker.pull(BASE_IMAGE);
+	// Wait for alpine:latest to finish pulling
+	while (true) {
+		if ((await docker.listImages()).length > 0) {
+			break;
+		}
+		await setTimeout(500);
+	}
+	// Tag alpine as balena/$ARCH-supervisor:latest
+	await docker
+		.getImage(BASE_IMAGE)
+		.tag({ repo: supervisorImage, tag: 'latest' });
+};
+
+/**
+ * Clean up Docker artifacts from integration tests.
+ */
+export const cleanupDocker = async ({
+	docker = new Docker(),
+	imagesToExclude = [BASE_IMAGE, supervisorImage],
+} = {}) => {
+	// Remove all containers
+	// Some containers may still be running so a prune won't suffice
+	try {
+		const containers = await docker.listContainers({ all: true });
+		await Promise.all(
+			containers.map(({ Id }) =>
+				docker.getContainer(Id).remove({ force: true }),
+			),
+		);
+	} catch (e: unknown) {
+		// Sometimes a container is already in the process of being removed
+		// This is safe to ignore since we're removing them anyway.
+		if (isStatusError(e) && e.statusCode !== 409) {
+			throw e;
+		}
+	}
+
+	// Remove all networks except defaults
+	const networks = await docker.listNetworks();
+	await Promise.all(
+		networks
+			// exclude docker default network from the cleanup
+			.filter(({ Name }) => !['bridge', 'host', 'none'].includes(Name))
+			.map(({ Name }) => docker.getNetwork(Name).remove()),
+	);
+
+	// Remove all volumes
+	await docker.pruneVolumes();
+
+	// Remove all images except optionally excluded ones
+	const images = await docker.listImages();
+	const toRemove = images
+		.filter(
+			({ RepoTags }) => !imagesToExclude.some((img) => RepoTags.includes(img)),
+		)
+		.map(({ RepoTags }) => RepoTags)
+		.flat();
+	// Remove images in serial because removing 2 tags referencing
+	// the same image at once will error
+	for (const repoTag of toRemove) {
+		await docker.getImage(repoTag).remove();
+	}
+};


### PR DESCRIPTION
In integration test env, the Supervisor container expects an image tagged balena/$ARCH-supervisor to be able to apply target state. We can't access the SV container for stubbing the method that checks the presence of this image, so a minimal image should be pulled and tagged.

Change-type: patch
Signed-off-by: Christina Ying Wang <christina@balena.io>