### PR TITLE
Use local socket for tests instead of dind

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,26 +9,27 @@ services:
       dockerfile: Dockerfile.template
       args:
         ARCH: ${ARCH:-amd64}
-    command: [ '/wait-for-it.sh', '--', '/usr/src/app/entry.sh' ]
+    image: ${ARCH:-amd64}-supervisor
+    command: ['/wait-for-it.sh', '--', '/usr/src/app/entry.sh']
     # Use bridge networking for the tests
     network_mode: 'bridge'
     networks:
       - default
     environment:
-      DOCKER_HOST: tcp://docker:2375
+      DOCKER_HOST: unix:///var/run/docker.sock
       DBUS_SYSTEM_BUS_ADDRESS: unix:path=/run/dbus/system_bus_socket
       # Required by migrations
       CONFIG_MOUNT_POINT: /mnt/root/mnt/boot/config.json
       # Read by constants to setup `bootMountpoint`
       BOOT_MOUNTPOINT: /mnt/boot
     depends_on:
-      - docker
       - dbus
       - dbus-services
     volumes:
       - dbus:/run/dbus
       - ./test/data/root:/mnt/root
       - ./test/lib/wait-for-it.sh:/wait-for-it.sh
+      - /var/run/docker.sock:/var/run/docker.sock
     tmpfs:
       - /data # sqlite3 database
 
@@ -51,13 +52,6 @@ services:
     environment:
       DBUS_SYSTEM_BUS_ADDRESS: unix:path=/run/dbus/system_bus_socket
 
-  docker:
-    image: docker:dind
-    privileged: true
-    environment:
-      DOCKER_TLS_CERTDIR: ''
-    command: --tls=false # --debug
-
   sut:
     # Build the supervisor code for development and testing
     build:
@@ -74,18 +68,18 @@ services:
         '--',
         'npm',
         'run',
-        'test:integration'
+        'test:integration',
       ]
     depends_on:
       - balena-supervisor
-      - docker
       - dbus
       - dbus-services
     volumes:
       - dbus:/run/dbus
+      - /var/run/docker.sock:/var/run/docker.sock
     # Set required supervisor configuration variables here
     environment:
-      DOCKER_HOST: tcp://docker:2375
+      DOCKER_HOST: unix:///var/run/docker.sock
       DBUS_SYSTEM_BUS_ADDRESS: unix:path=/run/dbus/system_bus_socket
       BALENA_SUPERVISOR_ADDRESS: http://balena-supervisor:48484
       # Required by migrations

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:env": "ARCH=$(./build-utils/detect-arch.sh) docker-compose -f docker-compose.test.yml -f docker-compose.dev.yml up --build; npm run compose:down",
     "test:compose": "ARCH=$(./build-utils/detect-arch.sh) docker-compose -f docker-compose.yml -f docker-compose.test.yml up --build --remove-orphans --exit-code-from=sut ; npm run compose:down",
     "test": "npm run lint && npm run test:build && npm run test:unit && npm run test:legacy",
-    "compose:down": "docker-compose -f docker-compose.test.yml down && docker volume rm $(docker volume ls -f name=balena-supervisor -q)",
+    "compose:down": "docker-compose -f docker-compose.test.yml down && docker volume prune -f",
     "prettify": "balena-lint -e ts -e js --fix src/ test/ typings/ build-utils/ webpack.config.js",
     "release": "tsc --project tsconfig.release.json && mv build/src/* build",
     "sync": "ts-node --files sync/sync.ts",

--- a/test/integration/compose/application-manager.spec.ts
+++ b/test/integration/compose/application-manager.spec.ts
@@ -194,15 +194,9 @@ describe('compose/application-manager', () => {
 	});
 
 	afterEach(async () => {
-		// Delete any created networks
+		// Delete any unreferenced networks
 		const docker = new Docker();
-		const allNetworks = await docker.listNetworks();
-		await Promise.all(
-			allNetworks
-				// exclude docker default networks from the cleanup
-				.filter(({ Name }) => !['bridge', 'host', 'none'].includes(Name))
-				.map(({ Name }) => docker.getNetwork(Name).remove()),
-		);
+		await docker.pruneNetworks();
 	});
 
 	// TODO: we don't test application manager initialization as it sets up a bunch of timers

--- a/test/integration/compose/network.spec.ts
+++ b/test/integration/compose/network.spec.ts
@@ -5,17 +5,11 @@ import { createNetwork, withMockerode } from '~/test-lib/mockerode';
 
 import * as Docker from 'dockerode';
 
-describe('compose/network: integration tests', () => {
+describe('compose/network', () => {
 	const docker = new Docker();
-	after(async () => {
-		const allNetworks = await docker.listNetworks();
 
-		// Delete any remaining networks
-		await Promise.all(
-			allNetworks
-				.filter(({ Name }) => !['bridge', 'host', 'none'].includes(Name)) // exclude docker default network from the cleanup
-				.map(({ Name }) => docker.getNetwork(Name).remove()),
-		);
+	after(async () => {
+		await docker.pruneNetworks();
 	});
 
 	describe('creating and removing networks', () => {

--- a/test/integration/compose/volume-manager.spec.ts
+++ b/test/integration/compose/volume-manager.spec.ts
@@ -46,7 +46,7 @@ describe('compose/volume-manager', () => {
 			]);
 
 			// Perform test
-			await expect(volumeManager.getAll()).to.eventually.have.deep.members([
+			await expect(volumeManager.getAll()).to.eventually.include.deep.members([
 				{
 					appId: 1,
 					appUuid: undefined,
@@ -278,17 +278,13 @@ describe('compose/volume-manager', () => {
 				]),
 			).to.not.be.rejected;
 
-			// All volumes should have been deleted
-			expect(await docker.listVolumes())
-				.to.have.property('Volumes')
-				.that.has.lengthOf(2);
-
-			// Reference volume should have been kept
-			await expect(
-				docker.getVolume(Volume.generateDockerName(111, 'main')).inspect(),
-			).to.not.be.rejected;
-			await expect(docker.getVolume('other-volume').inspect()).to.not.be
-				.rejected;
+			// Volumes not in the target state or not referenced should have been deleted
+			expect(
+				(await docker.listVolumes()).Volumes.map(({ Name }) => Name),
+			).to.include.members([
+				Volume.generateDockerName(111, 'main'),
+				'other-volume',
+			]);
 
 			// Cleanup
 			await Promise.all([

--- a/test/integration/compose/volume.spec.ts
+++ b/test/integration/compose/volume.spec.ts
@@ -23,10 +23,7 @@ describe('compose/volume: integration tests', () => {
 		});
 
 		after(async () => {
-			const { Volumes: allVolumes } = await docker.listVolumes();
-			await Promise.all(
-				allVolumes.map(({ Name }) => docker.getVolume(Name).remove()),
-			);
+			await docker.pruneVolumes();
 			(logger.logSystemEvent as SinonStub).restore();
 		});
 

--- a/test/integration/lib/docker-utils.spec.ts
+++ b/test/integration/lib/docker-utils.spec.ts
@@ -28,14 +28,8 @@ describe('lib/docker-utils', () => {
 		});
 
 		after(async () => {
-			const allNetworks = await docker.listNetworks();
-
-			// Delete any remaining networks
-			await Promise.all(
-				allNetworks
-					.filter(({ Name }) => !['bridge', 'host', 'none'].includes(Name)) // exclude docker default network from the cleanup
-					.map(({ Name }) => docker.getNetwork(Name).remove()),
-			);
+			// Cleanup networks
+			await docker.pruneNetworks();
 		});
 
 		// test using existing data...


### PR DESCRIPTION
While this breaks a bit the isolation of the tests, is a bit more realistic in the sense that the supervisor is running in the same engine as the rest of the containers.

Change-type: patch