### PR TITLE
Fix locking stubs that were returning `Bluebird` rather than `Promise`

### DIFF
--- a/test/legacy/41-device-api-v1.spec.ts
+++ b/test/legacy/41-device-api-v1.spec.ts
@@ -1,5 +1,4 @@
 import * as _ from 'lodash';
-import * as Bluebird from 'bluebird';
 import { expect } from 'chai';
 import {
 	stub,
@@ -419,9 +418,9 @@ describe('SupervisorAPI [V1 Endpoints]', () => {
 		});
 
 		it('should return 423 and reject the reboot if no locks are set', async () => {
-			stub(updateLock, 'lock').callsFake((__, opts, fn) => {
+			stub(updateLock, 'lock').callsFake(async (__, opts, fn) => {
 				if (opts.force) {
-					return Bluebird.resolve(fn());
+					return fn();
 				}
 				throw new UpdatesLockedError('Updates locked');
 			});
@@ -457,9 +456,9 @@ describe('SupervisorAPI [V1 Endpoints]', () => {
 		});
 
 		it('should return 202 and reboot if force is set to true', async () => {
-			stub(updateLock, 'lock').callsFake((__, opts, fn) => {
+			stub(updateLock, 'lock').callsFake(async (__, opts, fn) => {
 				if (opts.force) {
-					return Bluebird.resolve(fn());
+					return fn();
 				}
 				throw new UpdatesLockedError('Updates locked');
 			});
@@ -584,9 +583,9 @@ describe('SupervisorAPI [V1 Endpoints]', () => {
 		});
 
 		it('should return 423 and reject the reboot if locks are set', async () => {
-			stub(updateLock, 'lock').callsFake((__, opts, fn) => {
+			stub(updateLock, 'lock').callsFake(async (__, opts, fn) => {
 				if (opts.force) {
-					return Bluebird.resolve(fn());
+					return fn();
 				}
 				throw new UpdatesLockedError('Updates locked');
 			});
@@ -622,9 +621,9 @@ describe('SupervisorAPI [V1 Endpoints]', () => {
 		});
 
 		it('should return 202 and shutdown if force is set to true', async () => {
-			stub(updateLock, 'lock').callsFake((__, opts, fn) => {
+			stub(updateLock, 'lock').callsFake(async (__, opts, fn) => {
 				if (opts.force) {
-					return Bluebird.resolve(fn());
+					return fn();
 				}
 				throw new UpdatesLockedError('Updates locked');
 			});
@@ -969,9 +968,9 @@ describe('SupervisorAPI [V1 Endpoints]', () => {
 			});
 
 			it('prevents patch if update locks are present', async () => {
-				stub(updateLock, 'lock').callsFake((__, opts, fn) => {
+				stub(updateLock, 'lock').callsFake(async (__, opts, fn) => {
 					if (opts.force) {
-						return Bluebird.resolve(fn());
+						return fn();
 					}
 					throw new UpdatesLockedError('Updates locked');
 				});
@@ -998,9 +997,9 @@ describe('SupervisorAPI [V1 Endpoints]', () => {
 			});
 
 			it('allows patch while update locks are present if force is in req.body', async () => {
-				stub(updateLock, 'lock').callsFake((__, opts, fn) => {
+				stub(updateLock, 'lock').callsFake(async (__, opts, fn) => {
 					if (opts.force) {
-						return Bluebird.resolve(fn());
+						return fn();
 					}
 					throw new UpdatesLockedError('Updates locked');
 				});

--- a/test/legacy/42-device-api-v2.spec.ts
+++ b/test/legacy/42-device-api-v2.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { stub, SinonStub, spy, SinonSpy } from 'sinon';
 import * as supertest from 'supertest';
-import * as Bluebird from 'bluebird';
 
 import sampleResponses = require('~/test-data/device-api-responses.json');
 import mockedAPI = require('~/test-lib/mocked-device-api');
@@ -407,9 +406,13 @@ describe('SupervisorAPI [V2 Endpoints]', () => {
 
 		const mockContainers = [mockedAPI.mockService(service)];
 		const mockImages = [mockedAPI.mockImage(service)];
-		const lockFake = (_: any, opts: { force: boolean }, fn: () => any) => {
+		const lockFake = async (
+			_: any,
+			opts: { force: boolean },
+			fn: () => any,
+		) => {
 			if (opts.force) {
-				return Bluebird.resolve(fn());
+				return fn();
 			}
 
 			throw new UpdatesLockedError('Updates locked');


### PR DESCRIPTION
Change-type: patch

*If this is a regression, consider adding it to #1898!*

# Description

Please include a summary of the change and which issue was fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Type of change

Include at least one commit in your PR that marks the change-type. This can be either specified through a Change-type footer, or by adding the change-type as a prefix to the commit, i.e. minor: Add some new feature. This is so the PR can be automatically versioned and a changelog generated for it by using versionist. Check out [semver](https://semver.org/) for a detailed explanation of the different possible change-type values.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
