### PR TITLE
Create default network as config-only when services have host networking

### DIFF
--- a/src/compose/app.ts
+++ b/src/compose/app.ts
@@ -77,12 +77,20 @@ export class App {
 		this.isHost = !!opts.isHost;
 
 		if (this.networks.default == null && isTargetState) {
+			const allHostNetworking = this.services.every(
+				(svc) => svc.config.networkMode === 'host',
+			);
 			// We always want a default network
 			this.networks.default = Network.fromComposeObject(
 				'default',
 				opts.appId,
-				opts.appUuid!, // app uuid always exists on the target state
-				{},
+				// app uuid always exists on the target state
+				opts.appUuid!,
+				// We don't want the default bridge to have actual addresses at all if services
+				// aren't using it, to minimize chances of host-Docker address conflicts.
+				// If config_only is specified, the network is created and available in Docker
+				// by name and config only, and no actual networking setup occurs.
+				{ config_only: allHostNetworking },
 			);
 		}
 	}

--- a/src/compose/types/network.ts
+++ b/src/compose/types/network.ts
@@ -1,3 +1,11 @@
+import { NetworkInspectInfo as DockerNetworkInspectInfo } from 'dockerode';
+
+// TODO: ConfigOnly is part of @types/dockerode@v3.2.0, but that version isn't
+// compatible with `resin-docker-build` which is used for `npm run sync`.
+export interface NetworkInspectInfo extends DockerNetworkInspectInfo {
+	ConfigOnly: boolean;
+}
+
 export interface ComposeNetworkConfig {
 	driver: string;
 	driver_opts: Dictionary<string>;
@@ -16,6 +24,7 @@ export interface ComposeNetworkConfig {
 	enable_ipv6: boolean;
 	internal: boolean;
 	labels: Dictionary<string>;
+	config_only: boolean;
 }
 export interface NetworkConfig {
 	driver: string;
@@ -33,4 +42,5 @@ export interface NetworkConfig {
 	internal: boolean;
 	labels: { [labelName: string]: string };
 	options: { [optName: string]: string };
+	configOnly: boolean;
 }

--- a/test/integration/compose/network.spec.ts
+++ b/test/integration/compose/network.spec.ts
@@ -69,6 +69,7 @@ describe('compose/network: integration tests', () => {
 					'io.balena.app-id': '12345',
 				},
 				Options: {},
+				ConfigOnly: false,
 			});
 
 			// Test network removal

--- a/test/lib/mockerode.ts
+++ b/test/lib/mockerode.ts
@@ -78,6 +78,7 @@ export function createNetwork(network: PartialNetworkInspectInfo) {
 		Containers: {},
 		Options: {},
 		Labels: {},
+		ConfigOnly: false,
 
 		// Add defaults
 		...networkInspect,

--- a/test/unit/compose/network.spec.ts
+++ b/test/unit/compose/network.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 
 import { Network } from '~/src/compose/network';
-import { NetworkInspectInfo } from 'dockerode';
+import { NetworkInspectInfo } from '~/src/compose/types/network';
 
 import { log } from '~/lib/supervisor-console';
 
@@ -32,6 +32,7 @@ describe('compose/network', () => {
 				'io.balena.app-id': '12345',
 			});
 			expect(network.config.options).to.deep.equal({});
+			expect(network.config.configOnly).to.equal(false);
 		});
 
 		it('normalizes legacy labels', () => {
@@ -152,6 +153,7 @@ describe('compose/network', () => {
 				labels: {
 					'com.docker.some-label': 'yes',
 				},
+				config_only: true,
 			});
 
 			const dockerConfig = network1.toDockerConfig();
@@ -174,7 +176,9 @@ describe('compose/network', () => {
 					},
 				],
 			});
-
+			// If ConfigOnly is true, Subnet & Gateway remain in config
+			// but no actual networks are created.
+			expect(dockerConfig.ConfigOnly).to.equal(true);
 			expect(dockerConfig.Labels).to.deep.equal({
 				'io.balena.supervised': 'true',
 				'io.balena.app-id': '12345',
@@ -251,6 +255,7 @@ describe('compose/network', () => {
 					'io.balena.supervised': 'true',
 					'io.balena.features.something': '123',
 				} as NetworkInspectInfo['Labels'],
+				ConfigOnly: false,
 			} as NetworkInspectInfo);
 
 			expect(network.appId).to.equal(1234);
@@ -271,6 +276,7 @@ describe('compose/network', () => {
 			expect(network.config.labels).to.deep.equal({
 				'io.balena.features.something': '123',
 			});
+			expect(network.config.configOnly).to.equal(false);
 		});
 
 		it('creates a network object from a docker network configuration', () => {
@@ -299,6 +305,7 @@ describe('compose/network', () => {
 					'io.balena.features.something': '123',
 					'io.balena.app-id': '1234',
 				} as NetworkInspectInfo['Labels'],
+				ConfigOnly: false,
 			} as NetworkInspectInfo);
 
 			expect(network.appId).to.equal(1234);
@@ -321,6 +328,7 @@ describe('compose/network', () => {
 				'io.balena.features.something': '123',
 				'io.balena.app-id': '1234',
 			});
+			expect(network.config.configOnly).to.equal(false);
 		});
 
 		it('normalizes legacy label names and excludes supervised label', () => {
@@ -372,6 +380,7 @@ describe('compose/network', () => {
 					'io.balena.features.something': '123',
 					'io.balena.app-id': '12345',
 				} as NetworkInspectInfo['Labels'],
+				ConfigOnly: true,
 			} as NetworkInspectInfo);
 
 			expect(network.appId).to.equal(12345);
@@ -399,6 +408,7 @@ describe('compose/network', () => {
 				'io.balena.features.something': '123',
 				'io.balena.app-id': '12345',
 			});
+			expect(compose.config_only).to.equal(true);
 		});
 	});
 


### PR DESCRIPTION
This eliminates chances of host-Docker address collision for apps such as the Supervisor where all services have host networking.

Context: [internal thread](https://balena.zulipchat.com/#narrow/stream/345889-loop.2Fbalena-os/topic/Supervisor.20v13.2B.20default.20Docker.20network)

Closes: #2062
Change-type: patch
Signed-off-by: Christina Ying Wang <christina@balena.io>