### PR TITLE
Make readFromBoot behave more like Node readFile

### DIFF
--- a/src/host-config.ts
+++ b/src/host-config.ts
@@ -117,7 +117,8 @@ function generateRedsocksConfEntries(conf: ProxyConfig): string {
 		let v = conf[field];
 		if (v != null) {
 			if (isAuthField(field)) {
-				v = `"${v}"`;
+				// Escape any quotes in the field value
+				v = `"${v.toString().replace(/"/g, '\\"')}"`;
 			}
 			val += `\t${field} = ${v};\n`;
 		}


### PR DESCRIPTION
The `readFromBoot` function replaced calls to readFile in the codebase
when the target location is under `/mnt/boot` in order to use `fatrw`
to check for corruption. Unfortunately this function behaved a little
differently with regards to errors. While `readFile` returns a code `ENOENT`
when the file is not found, `readFromBoot` would just throw an exception
with whatever code was given by fatrw. This would cause confusion for
some calls that were behaving differently with a `ENOENT`, causing some
issues.

This PR fixes that issue and also adds an additional input sanitization in case the PATCHEd configuration 
includes quotes.

Relates-to:  #2071
Relates-to:  #2072
Change-type: patch