### PR TITLE
Feature: Support `since` and `until` in supervisor journald wrapper

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1291,5 +1291,15 @@ From an app container:
 $ curl -X POST -H "Content-Type: application/json" --data '{"follow":true,"all":true}' "$BALENA_SUPERVISOR_ADDRESS/v2/journal-logs?apikey=$BALENA_SUPERVISOR_API_KEY" > log.journal
 ```
 
+##### since: string
+> **Introduced in supervisor v14.7.0**
+Show journal logs since the given `since` timestamp, formats are described here:
+[https://www.freedesktop.org/software/systemd/man/journalctl.html#-S](https://www.freedesktop.org/software/systemd/man/journalctl.html#-S)
+
+##### until: string
+> **Introduced in supervisor v14.7.0**
+Show journal logs until the given `until` timestamp, formats are described here:
+[https://www.freedesktop.org/software/systemd/man/journalctl.html#-S](https://www.freedesktop.org/software/systemd/man/journalctl.html#-S)
+
 An example project using this endpoint can be found
 [in this repository](https://github.com/balena-io-playground/device-cloud-logging).

--- a/src/device-api/v2.ts
+++ b/src/device-api/v2.ts
@@ -549,6 +549,8 @@ router.post('/v2/journal-logs', (req, res) => {
 	const unit = req.body.unit;
 	const format = req.body.format || 'short';
 	const containerId = req.body.containerId;
+	const since = req.body.since;
+	const until = req.body.until;
 
 	const journald = spawnJournalctl({
 		all,
@@ -557,6 +559,8 @@ router.post('/v2/journal-logs', (req, res) => {
 		unit,
 		format,
 		containerId,
+		since,
+		until,
 	});
 	res.status(200);
 	// We know stdout will be present

--- a/src/lib/journald.ts
+++ b/src/lib/journald.ts
@@ -10,7 +10,8 @@ export function spawnJournalctl(opts: {
 	containerId?: string;
 	format: string;
 	filterString?: string;
-	since?: number;
+	since?: number | string;
+	until?: number | string;
 }): ChildProcess {
 	const args: string[] = [];
 	if (opts.all) {
@@ -33,12 +34,11 @@ export function spawnJournalctl(opts: {
 	}
 	if (opts.since != null) {
 		args.push('-S');
-		args.push(
-			new Date(opts.since)
-				.toISOString()
-				.replace(/T/, ' ') // replace T with a space
-				.replace(/\..+/, ''), // delete the dot and everything after
-		);
+		args.push(opts.since.toString());
+	}
+	if (opts.until != null) {
+		args.push('-U');
+		args.push(opts.until.toString());
 	}
 	args.push('-o');
 	args.push(opts.format);

--- a/test/unit/lib/journald.spec.ts
+++ b/test/unit/lib/journald.spec.ts
@@ -26,6 +26,8 @@ describe('lib/journald', () => {
 			unit: 'nginx.service',
 			containerId: 'abc123',
 			format: 'json-pretty',
+			since: '2014-03-25 03:59:56.654563',
+			until: '2014-03-25 03:59:59.654563',
 		});
 
 		const expectedCommand = `journalctl`;
@@ -40,6 +42,10 @@ describe('lib/journald', () => {
 			'10',
 			'-o',
 			'json-pretty',
+			'-S',
+			'2014-03-25 03:59:56.654563',
+			'-U',
+			'2014-03-25 03:59:59.654563',
 		];
 
 		const actualCommand = spawn.firstCall.args[0];


### PR DESCRIPTION
# Description
The currently implemented API endpoint contains a [subset](https://www.balena.io/docs/reference/supervisor/supervisor-api/#journald-logs) of the journalctl functionality. To retrieve logs within a closed time interval without manually filtering all retrieved logs, support for `since` and `until` is welcome.

Fixes #2083

# Type of change
Change-type: minor

# Notes
- The `since` timestamp was already supported at the library side in `src/lib/journald.ts`, only the argument was not passed from the request body in `src/device-api/v2.ts`. At the library side the type of the `since` timestamp is defined to be a `number`. Therefore, it is assumed that this API was designed to take a UNIX timestamp as input. Since no type checking is happening at runtime, users could theoretically also pass any other argument valid to the javascript `Date()` constructor, if this is the desired API, the documentation should be adjusted accordingly. 

# How Has This Been Tested?
Tested with a device registered in Balena connected to the local network, using [these instructions](https://github.com/balena-os/balena-supervisor#developing-using-a-production-image-or-device).