### PR TITLE
Allow using colon character in config vars

### DIFF
--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -7,6 +7,7 @@ import { ComposeVolumeConfig } from '../compose/volume';
 import {
 	DockerName,
 	EnvVarObject,
+	ConfigVarObject,
 	LabelObject,
 	NumericIdentifier,
 	ShortString,
@@ -274,7 +275,7 @@ export type TargetApps = t.TypeOf<typeof TargetApps>;
 const TargetDevice = t.intersection([
 	t.type({
 		name: DeviceName,
-		config: EnvVarObject,
+		config: ConfigVarObject,
 		apps: TargetApps,
 	}),
 	t.partial({
@@ -350,7 +351,7 @@ const TargetAppWithRelease = t.intersection([
 
 export const AppsJsonFormat = t.intersection([
 	t.type({
-		config: withDefault(EnvVarObject, {}),
+		config: withDefault(ConfigVarObject, {}),
 		apps: withDefault(t.record(UUID, TargetAppWithRelease), {}),
 	}),
 	t.partial({ pinDevice: t.boolean }),

--- a/test/unit/lib/validation.spec.ts
+++ b/test/unit/lib/validation.spec.ts
@@ -8,6 +8,7 @@ import {
 	DeviceName,
 	NumericIdentifier,
 	TargetApps,
+	TargetState,
 } from '~/src/types';
 
 import * as validation from '~/lib/validation';
@@ -485,6 +486,49 @@ describe('validation', () => {
 								aaaa: {
 									id: 'boooo',
 									services: {},
+								},
+							},
+						},
+					}),
+				),
+			).to.be.false;
+		});
+	});
+
+	describe('target state', () => {
+		it('accepts target state with config vars and apps', () => {
+			expect(
+				isRight(
+					TargetState.decode({
+						one: {
+							name: 'angry-einstein',
+							config: {
+								BALENA_HOST_CONFIG_hdmi_force_hotplug: '0',
+								'BALENA_HOST_CONFIG_hdmi_force_hotplug:1': '1',
+								BALENA_HOST_CONFIG_dtoverlay: 'balena-fin',
+							},
+							apps: {},
+						},
+					}),
+				),
+			).to.be.true;
+		});
+
+		it('rejects target state with an invalid config vars', () => {
+			expect(
+				isRight(
+					TargetState.decode({
+						one: {
+							name: 'angry-einstein',
+							config: {
+								'BALENA_CONFIG_ INVALID VAR': '123',
+							},
+							apps: {
+								abcd: {
+									id: 1234,
+									name: 'something',
+									class: 'fleet',
+									releases: {},
 								},
 							},
 						},


### PR DESCRIPTION
The Raspberry Pi config.txt file defines the use of colon to configure variables of the same name in different ports, for instance on those devices with two hdmi ports. This syntax was previously not supported by the supervisor. This change relaxes the syntax validation on config vars to allow the use of the colon character.

Relates-to: #1573, #2046
Change-type: minor