### PR TITLE
Remove custom action restriction for external contributors

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -20,6 +20,7 @@ jobs:
       (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     secrets: inherit
     with:
+      restrict_custom_actions: false
       balena_slugs: |
         balena_os/aarch64-supervisor,
         balena_os/amd64-supervisor,


### PR DESCRIPTION
Found that custom actions are disabled by default for external contributions, as in https://github.com/balena-os/balena-supervisor/pull/2084. This PR enables them.

Change-type: patch
Signed-off-by: Christina Ying Wang <christina@balena.io>