### PR TITLE
patch: Convert internal timestamp passed to journalctl from number to string

### DIFF
--- a/src/lib/journald.ts
+++ b/src/lib/journald.ts
@@ -2,6 +2,17 @@ import { ChildProcess, spawn } from 'child_process';
 
 import log from './supervisor-console';
 
+/**
+ * Given a date integer in ms, return in a format acceptable by journalctl.
+ * This function is intended to be used internally. Queries to POST /v2/journal-logs
+ * should provide `since` and `until` as formats acceptable by journalctl and not
+ * rely on the Supervisor to convert inputs into an appropriate format.
+ *
+ * Example output: '2014-03-25 03:59:56'
+ */
+export const toJournalDate = (timestamp: number): string =>
+	new Date(timestamp).toISOString().replace(/T/, ' ').replace(/\..+$/, '');
+
 export function spawnJournalctl(opts: {
 	all: boolean;
 	follow: boolean;
@@ -10,8 +21,8 @@ export function spawnJournalctl(opts: {
 	containerId?: string;
 	format: string;
 	filterString?: string;
-	since?: number | string;
-	until?: number | string;
+	since?: string;
+	until?: string;
 }): ChildProcess {
 	const args: string[] = [];
 	if (opts.all) {
@@ -34,11 +45,11 @@ export function spawnJournalctl(opts: {
 	}
 	if (opts.since != null) {
 		args.push('-S');
-		args.push(opts.since.toString());
+		args.push(opts.since);
 	}
 	if (opts.until != null) {
 		args.push('-U');
-		args.push(opts.until.toString());
+		args.push(opts.until);
 	}
 	args.push('-o');
 	args.push(opts.format);

--- a/src/logging/monitor.ts
+++ b/src/logging/monitor.ts
@@ -2,7 +2,7 @@ import * as JSONstream from 'JSONStream';
 import { delay } from 'bluebird';
 
 import * as db from '../db';
-import { spawnJournalctl } from '../lib/journald';
+import { spawnJournalctl, toJournalDate } from '../lib/journald';
 import log from '../lib/supervisor-console';
 
 export type MonitorHook = ({
@@ -152,7 +152,7 @@ class LogMonitor {
 				follow: false,
 				format: 'json',
 				filterString: `CONTAINER_ID_FULL=${containerId}`,
-				since: lastSentTimestamp + 1, // increment to exclude last sent log
+				since: toJournalDate(lastSentTimestamp + 1), // increment to exclude last sent log
 			},
 			(row: JournalRow) => this.handleRow(row),
 			async (data: Buffer) => {


### PR DESCRIPTION
Following PR #2084, I discovered that logging/monitor.ts was passing `since` to `spawnJournalctl` as a number, whereas `journalctl` (and `spawnJournalctl`, our wrapper) only accepts dates formatted in accordance with the systemd.time spec. (`YYYY-MM-DD HH:MM:SS(.s*)`). Thus I added back in [this commit](https://github.com/balena-os/balena-supervisor/commit/cb468b298a7cb87ffbd486dfd5482d5f2e43bb14) from @rkeulemans  for internal use only.

See: https://github.com/balena-os/balena-supervisor/pull/2084
Change-type: patch
Signed-off-by: Christina Ying Wang <christina@balena.io>