### PR TITLE
Find and remove duplicate networks

### DIFF
--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -242,8 +242,8 @@ export async function inferNextSteps(
 					{
 						appId,
 						services: [],
-						volumes: {},
-						networks: {},
+						volumes: [],
+						networks: [],
 					},
 					false,
 				);
@@ -352,8 +352,8 @@ export async function getCurrentApps(): Promise<InstancedAppState> {
 					appUuid: uuid,
 					commit,
 					services: componentGroups[appId].services,
-					networks: _.keyBy(componentGroups[appId].networks, 'name'),
-					volumes: _.keyBy(componentGroups[appId].volumes, 'name'),
+					networks: componentGroups[appId].networks,
+					volumes: componentGroups[appId].volumes,
 				},
 				false,
 			);

--- a/src/compose/network-manager.ts
+++ b/src/compose/network-manager.ts
@@ -11,10 +11,10 @@ import * as logger from '../logger';
 import { Network } from './network';
 import { ResourceRecreationAttemptError } from './errors';
 
-export function getAll(): Bluebird<Network[]> {
-	return getWithBothLabels().map((network: { Name: string }) => {
+export async function getAll(): Promise<Network[]> {
+	return getWithBothLabels().map(async (network: { Id: string }) => {
 		return docker
-			.getNetwork(network.Name)
+			.getNetwork(network.Id)
 			.inspect()
 			.then((net) => {
 				return Network.fromDockerNetwork(net);

--- a/src/device-api/actions.ts
+++ b/src/device-api/actions.ts
@@ -234,7 +234,7 @@ export const doPurge = async (appId: number, force: boolean = false) => {
 		const clonedState = safeStateClone(currentState);
 		// Set services & volumes as empty to be applied as intermediate state
 		app.services = [];
-		app.volumes = {};
+		app.volumes = [];
 
 		applicationManager.setIsApplyingIntermediate(true);
 

--- a/test/integration/device-state/db-format.spec.ts
+++ b/test/integration/device-state/db-format.spec.ts
@@ -8,9 +8,7 @@ import * as dbFormat from '~/src/device-state/db-format';
 import { TargetApps } from '~/src/types/state';
 
 function getDefaultNetwork(appId: number) {
-	return {
-		default: Network.fromComposeObject('default', appId, 'deadbeef', {}),
-	};
+	return [Network.fromComposeObject('default', appId, 'deadbeef', {})];
 }
 
 describe('device-state/db-format', () => {
@@ -119,7 +117,7 @@ describe('device-state/db-format', () => {
 		expect(app).to.have.property('appName').that.equals('test-app');
 		expect(app).to.have.property('source').that.equals(apiEndpoint);
 		expect(app).to.have.property('services').that.has.lengthOf(1);
-		expect(app).to.have.property('volumes').that.deep.equals({});
+		expect(app).to.have.property('volumes').that.deep.equals([]);
 		expect(app)
 			.to.have.property('networks')
 			.that.deep.equals(getDefaultNetwork(1));
@@ -194,7 +192,7 @@ describe('device-state/db-format', () => {
 		expect(app).to.have.property('appName').that.equals('test-app');
 		expect(app).to.have.property('source').that.equals(apiEndpoint);
 		expect(app).to.have.property('services').that.has.lengthOf(1);
-		expect(app).to.have.property('volumes').that.deep.equals({});
+		expect(app).to.have.property('volumes').that.deep.equals([]);
 		expect(app)
 			.to.have.property('networks')
 			.that.deep.equals(getDefaultNetwork(1));
@@ -303,7 +301,7 @@ describe('device-state/db-format', () => {
 		expect(newapp).to.have.property('appName').that.equals('test-app');
 		expect(newapp).to.have.property('source').that.equals('local');
 		expect(newapp).to.have.property('services').that.has.lengthOf(1);
-		expect(newapp).to.have.property('volumes').that.deep.equals({});
+		expect(newapp).to.have.property('volumes').that.deep.equals([]);
 		expect(newapp)
 			.to.have.property('networks')
 			.that.deep.equals(getDefaultNetwork(1));

--- a/test/lib/state-helper.ts
+++ b/test/lib/state-helper.ts
@@ -109,14 +109,8 @@ export function createApps(
 			{
 				appId,
 				services: servicesByAppId[appId] ?? [],
-				networks: (networksByAppId[appId] ?? []).reduce(
-					(nets, n) => ({ ...nets, [n.name]: n }),
-					{},
-				),
-				volumes: (volumesByAppId[appId] ?? []).reduce(
-					(vols, v) => ({ ...vols, [v.name]: v }),
-					{},
-				),
+				networks: networksByAppId[appId] ?? [],
+				volumes: volumesByAppId[appId] ?? [],
 			},
 			target,
 		);


### PR DESCRIPTION
We have seen a few times devices with duplicated network names for some
reason. While we don't know the cause the networks get duplicates, this
can be disruptive for updates as trying to create a container referencing a duplicate
network results in a 400 error from the engine.

This commit finds and removes duplicate networks via the state engine,
this means that even if somehow a container could be referencing a
network that has been duplicated later somehow, this will remove the
container first.

While thies doesn't solve the problem of duplicate networks being
created in the first place, it will fix the state of the system to
correct the inconsistency.

Change-type: minor
Closes: https://github.com/balena-os/balena-supervisor/issues/590