### PR TITLE
Skip pin device step if release was deleted

### DIFF
--- a/src/api-binder/index.ts
+++ b/src/api-binder/index.ts
@@ -302,9 +302,11 @@ async function pinDevice({ app, commit }: DevicePinInfo) {
 
 		const releaseId: number | undefined = release?.[0]?.id;
 		if (releaseId == null) {
-			throw new Error(
-				'Cannot continue pinning preloaded device! No release found!',
+			log.warn(
+				'Cannot pin device to release. Release no longer exists. Skipping.',
 			);
+			await config.remove('pinDevice');
+			return;
 		}
 
 		// We force a fresh get to make sure we have the latest state


### PR DESCRIPTION
Preloaded devices can require that the device is pinned to the preloaded release on provisioning. However if the provisioned release gets released in the future, that would lead to the device remaining in "VPN only" state forever as the provisioning process could not finish due to pinning failure.

This commit changes the behavior so if the release does not exist, the pinning step is skipped and the device follows the fleet pinning state.

Closes: #2133
Change-type: patch