### PR TITLE
Revert "Use multi-arch in dockerfile"

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,37 +1,43 @@
 ARG ARCH=%%BALENA_ARCH%%
 ARG FATRW_VERSION=0.2.9
-ARG NODE="nodejs<18"
-ARG NPM="npm<9"
+
+
+FROM arm32v6/alpine:3.16 as alpine-rpi
+FROM arm32v7/alpine:3.16 as alpine-armv7hf
+FROM arm64v8/alpine:3.16 as alpine-aarch64
+FROM amd64/alpine:3.16 as alpine-amd64
+FROM i386/alpine:3.16 as alpine-i386
+
+FROM arm32v6/alpine:3.11 as procmail-rpi
+FROM arm32v7/alpine:3.11 as procmail-armv7hf
+FROM arm64v8/alpine:3.11 as procmail-aarch64
+FROM amd64/alpine:3.11 as procmail-amd64
+FROM i386/alpine:3.11 as procmail-i386
 
 ###################################################
 # Build the supervisor dependencies
 ###################################################
-FROM alpine:3.16 as build-base
+FROM balenalib/${ARCH}-alpine-node:16-run as build-base
 
 ARG ARCH
-ARG NODE
-ARG NPM
 ARG FATRW_VERSION
 ARG FATRW_ARCHIVE="fatrw-${ARCH}.tar.gz"
 ARG FATRW_LOCATION="https://github.com/balena-os/fatrw/releases/download/v${FATRW_VERSION}/${FATRW_ARCHIVE}"
 
 WORKDIR /usr/src/app
 
-RUN apk add --update --no-cache \
+RUN apk add --no-cache \
 	g++ \
 	make \
 	python3 \
-	curl \
-	$NODE \
-	$NPM \
+	libgcc \
 	libuv \
 	sqlite-dev \
-	dbus-dev && \
-	npm install -g npm@8
+	dbus-dev
 
 COPY package*.json ./
 
-RUN strip "$(which node)"
+RUN strip /usr/local/bin/node
 
 # Install fatrw
 RUN curl -SLO "${FATRW_LOCATION}" && \
@@ -49,7 +55,7 @@ RUN npm ci --build-from-source --sqlite=/usr/lib
 # musl. We hack around this by copying the binary and its library
 # dependencies to the final image
 ###################################################################
-FROM debian:bullseye-slim as journal
+FROM balenalib/${ARCH}-debian:bullseye-run as journal
 
 RUN apt-get update && apt-get install -y --no-install-recommends systemd
 
@@ -61,7 +67,7 @@ RUN /setup-journal.sh
 # Extra dependencies. This uses alpine 3.11 as the
 # procmail package was removed on 3.12
 ###################################################
-FROM alpine:3.11 as extra
+FROM procmail-${ARCH} as extra
 
 RUN apk add --update --no-cache procmail
 
@@ -69,11 +75,12 @@ RUN apk add --update --no-cache procmail
 # Image with the final production dependencies.
 # This image will also be be used for testing
 ###################################################
-FROM alpine:3.16 as runtime-base
-
-ARG NODE
+FROM alpine-${ARCH} as runtime-base
 
 WORKDIR /usr/src/app
+
+# We just need the node binary in the final image
+COPY --from=build-base /usr/local/bin/node /usr/local/bin/node
 
 # Also copy the fatrw binary
 COPY --from=build-base /usr/local/bin/fatrw /usr/local/bin/fatrw
@@ -85,12 +92,13 @@ COPY --from=extra /usr/bin/lockfile /usr/bin/lockfile
 COPY --from=journal /sysroot /
 
 # Runtime dependencies
-RUN apk add --update --no-cache \
-	$NODE \
+RUN apk add --no-cache \
+	ca-certificates \
 	iptables \
 	ip6tables \
 	rsync \
 	dbus \
+	libstdc++ \
 	dmidecode \
 	sqlite-libs
 
@@ -106,14 +114,11 @@ ENV CONFIG_MOUNT_POINT=/boot/config.json \
 ###############################################################
 FROM runtime-base as test
 
-ARG NPM
-ARG ARCH
-
-# We want to use as close to the final image when running tests
-# but we need npm so we install it here again
-RUN apk add --update --no-cache $NPM && npm install -g npm@8
-
 WORKDIR /usr/src/app
+
+# Copy node install from the build folder
+COPY --from=build-base /usr/local/bin /usr/local/bin
+COPY --from=build-base /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 # Copy build dependencies
 COPY --from=build-base /usr/src/app/package.json ./


### PR DESCRIPTION
This reverts commit 00e389e5f559dd10e49cfa411784b89498c3c0eb.

Images generated using this dockerfile still don't have the right architecture. More testing is needed

Change-type: patch
