### PR TITLE
Refactor state engine to be able to use current state as target

### DIFF
--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -123,6 +123,7 @@ export async function getRequiredSteps(
 	currentApps: InstancedAppState,
 	targetApps: InstancedAppState,
 	keepImages?: boolean,
+	keepVolumes?: boolean,
 ): Promise<CompositionStep[]> {
 	// get some required data
 	const [downloading, availableImages, { localMode, delta }] =
@@ -139,11 +140,15 @@ export async function getRequiredSteps(
 		keepImages = localMode;
 	}
 
+	if (keepVolumes == null) {
+		keepVolumes = localMode;
+	}
+
 	return await inferNextSteps(currentApps, targetApps, {
 		// Images are not removed while in local mode to avoid removing the user app images
 		keepImages,
 		// Volumes are not removed when stopping an app when going to local mode
-		keepVolumes: localMode,
+		keepVolumes,
 		delta,
 		downloading,
 		availableImages,

--- a/src/compose/composition-steps.ts
+++ b/src/compose/composition-steps.ts
@@ -258,10 +258,7 @@ export function getExecutors(app: {
 			await images.save(step.image);
 		},
 		cleanup: async () => {
-			const localMode = await config.get('localMode');
-			if (!localMode) {
-				await images.cleanup();
-			}
+			await images.cleanup();
 		},
 		createNetwork: async (step) => {
 			await networkManager.create(step.target);

--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -1074,20 +1074,17 @@ export class Service {
 			if (current.aliases == null) {
 				sameNetwork = false;
 			} else {
-				// Take out the container id from both aliases, as it *will* be present
-				// in a currently running container, and can also be present in the target
-				// for example when doing a start-service
-				// Also sort the aliases, so we can do a simple comparison
 				const [currentAliases, targetAliases] = [
 					current.aliases,
 					target.aliases,
-				].map((aliases) =>
-					_.sortBy(
-						aliases.filter((a) => !_.startsWith(this.containerId || '', a)),
-					),
-				);
+				];
 
-				sameNetwork = _.isEqual(currentAliases, targetAliases);
+				// Docker may add keep old container ids as aliases for a specific service after
+				// restarts, this means that the target aliases really needs to be a subset of the
+				// current aliases to prevent service restarts when re-applying the same target state
+				sameNetwork =
+					_.intersection(currentAliases, targetAliases).length ===
+					targetAliases.length;
 			}
 		}
 		if (target.ipv4Address != null) {

--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -515,6 +515,7 @@ export class Service {
 		if (_.get(container, 'NetworkSettings.Networks', null) != null) {
 			networks = ComposeUtils.dockerNetworkToServiceNetwork(
 				container.NetworkSettings.Networks,
+				svc.containerId,
 			);
 		}
 

--- a/src/device-api/actions.ts
+++ b/src/device-api/actions.ts
@@ -105,18 +105,16 @@ export const doRestart = async (appId: number, force: boolean = false) => {
 		app.services = [];
 
 		return deviceState
-			.pausingApply(() =>
-				deviceState
-					.applyIntermediateTarget(currentState, {
-						skipLock: true,
-					})
-					.then(() => {
-						app.services = services;
-						return deviceState.applyIntermediateTarget(currentState, {
-							skipLock: true,
-						});
-					}),
-			)
+			.applyIntermediateTarget(currentState, {
+				skipLock: true,
+			})
+			.then(() => {
+				app.services = services;
+				return deviceState.applyIntermediateTarget(currentState, {
+					skipLock: true,
+					keepVolumes: false,
+				});
+			})
 			.finally(() => {
 				deviceState.triggerApplyTarget();
 			});
@@ -230,21 +228,18 @@ export const doPurge = async (appId: number, force: boolean = false) => {
 		delete currentState.local.apps[appId];
 
 		return deviceState
-			.pausingApply(() =>
-				deviceState
-					.applyIntermediateTarget(currentState, {
-						skipLock: true,
-						// Purposely tell the apply function to delete volumes so they can get
-						// deleted even in local mode
-						keepVolumes: false,
-					})
-					.then(() => {
-						currentState.local.apps[appId] = app;
-						return deviceState.applyIntermediateTarget(currentState, {
-							skipLock: true,
-						});
-					}),
-			)
+			.applyIntermediateTarget(currentState, {
+				skipLock: true,
+				// Purposely tell the apply function to delete volumes so they can get
+				// deleted even in local mode
+				keepVolumes: false,
+			})
+			.then(() => {
+				currentState.local.apps[appId] = app;
+				return deviceState.applyIntermediateTarget(currentState, {
+					skipLock: true,
+				});
+			})
 			.finally(() => {
 				deviceState.triggerApplyTarget();
 			});

--- a/src/device-api/actions.ts
+++ b/src/device-api/actions.ts
@@ -362,11 +362,6 @@ export const executeServiceAction = async ({
 		throw new NotFoundError(messages.targetServiceNotFound);
 	}
 
-	// Set volatile target state
-	applicationManager.setTargetVolatileForService(currentService.imageId, {
-		running: action !== 'stop',
-	});
-
 	// Execute action on service
 	return await executeDeviceAction(
 		generateStep(action, {

--- a/src/device-api/v2.ts
+++ b/src/device-api/v2.ts
@@ -291,8 +291,7 @@ router.get(
 );
 
 router.get('/v2/local/target-state', async (_req, res) => {
-	const targetState = await deviceState.getTarget();
-	const target = actions.safeStateClone(targetState);
+	const target = await deviceState.getTarget();
 
 	res.status(200).json({
 		status: 'success',

--- a/src/device-state.ts
+++ b/src/device-state.ts
@@ -783,7 +783,7 @@ export const applyTarget = async ({
 	});
 };
 
-export function pausingApply(fn: () => any) {
+function pausingApply(fn: () => any) {
 	const lock = () => {
 		return writeLock('pause').disposer((release) => release());
 	};
@@ -873,11 +873,16 @@ export async function applyIntermediateTarget(
 		keepVolumes = undefined as boolean | undefined,
 	} = {},
 ) {
-	// TODO: Make sure we don't accidentally overwrite this
-	intermediateTarget = intermediate;
-	return applyTarget({ intermediate: true, force, skipLock, keepVolumes }).then(
-		() => {
+	return pausingApply(async () => {
+		// TODO: Make sure we don't accidentally overwrite this
+		intermediateTarget = intermediate;
+		return applyTarget({
+			intermediate: true,
+			force,
+			skipLock,
+			keepVolumes,
+		}).then(() => {
 			intermediateTarget = null;
-		},
-	);
+		});
+	});
 }

--- a/src/device-state.ts
+++ b/src/device-state.ts
@@ -671,6 +671,7 @@ export const applyTarget = async ({
 	skipLock = false,
 	nextDelay = 200,
 	retryCount = 0,
+	keepVolumes = undefined as boolean | undefined,
 } = {}) => {
 	if (!intermediate) {
 		await applyBlocker;
@@ -705,6 +706,7 @@ export const applyTarget = async ({
 				// if not applying intermediate, we let getRequired steps set
 				// the value
 				intermediate || undefined,
+				keepVolumes,
 			);
 
 			if (_.isEmpty(appSteps)) {
@@ -762,6 +764,7 @@ export const applyTarget = async ({
 				skipLock,
 				nextDelay,
 				retryCount,
+				keepVolumes,
 			});
 		} catch (e: any) {
 			if (e instanceof UpdatesLockedError) {
@@ -864,11 +867,17 @@ export function triggerApplyTarget({
 
 export async function applyIntermediateTarget(
 	intermediate: InstancedDeviceState,
-	{ force = false, skipLock = false } = {},
+	{
+		force = false,
+		skipLock = false,
+		keepVolumes = undefined as boolean | undefined,
+	} = {},
 ) {
 	// TODO: Make sure we don't accidentally overwrite this
 	intermediateTarget = intermediate;
-	return applyTarget({ intermediate: true, force, skipLock }).then(() => {
-		intermediateTarget = null;
-	});
+	return applyTarget({ intermediate: true, force, skipLock, keepVolumes }).then(
+		() => {
+			intermediateTarget = null;
+		},
+	);
 }

--- a/src/device-state.ts
+++ b/src/device-state.ts
@@ -555,6 +555,8 @@ export async function shutdown({
 	});
 }
 
+// FIXME: this method should not be exported, all target state changes
+// should happen via intermediate targets
 export async function executeStepAction(
 	step: DeviceStateStep<PossibleStepTargets>,
 	{

--- a/src/device-state.ts
+++ b/src/device-state.ts
@@ -701,6 +701,10 @@ export const applyTarget = async ({
 			const appSteps = await applicationManager.getRequiredSteps(
 				currentState.local.apps,
 				targetState.local.apps,
+				// Do not remove images while applying an intermediate state
+				// if not applying intermediate, we let getRequired steps set
+				// the value
+				intermediate || undefined,
 			);
 
 			if (_.isEmpty(appSteps)) {
@@ -858,7 +862,7 @@ export function triggerApplyTarget({
 	return null;
 }
 
-export function applyIntermediateTarget(
+export async function applyIntermediateTarget(
 	intermediate: InstancedDeviceState,
 	{ force = false, skipLock = false } = {},
 ) {

--- a/test/integration/device-api/actions.spec.ts
+++ b/test/integration/device-api/actions.spec.ts
@@ -237,7 +237,10 @@ describe('manages application lifecycle', () => {
 				containers.map((ctn) => ctn.State.StartedAt),
 			);
 
-			await actions.doRestart(APP_ID);
+			await request(BALENA_SUPERVISOR_ADDRESS)
+				.post(`/v1/restart`)
+				.set('Content-Type', 'application/json')
+				.send(JSON.stringify({ appId: APP_ID }));
 
 			const restartedContainers = await waitForSetup(
 				targetState,
@@ -503,7 +506,9 @@ describe('manages application lifecycle', () => {
 				containers.map((ctn) => ctn.State.StartedAt),
 			);
 
-			await actions.doRestart(APP_ID);
+			await request(BALENA_SUPERVISOR_ADDRESS)
+				.post(`/v2/applications/${APP_ID}/restart`)
+				.set('Content-Type', 'application/json');
 
 			const restartedContainers = await waitForSetup(
 				targetState,

--- a/test/unit/compose/app.spec.ts
+++ b/test/unit/compose/app.spec.ts
@@ -11,7 +11,7 @@ import { ServiceComposeConfig } from '~/src/compose/types/service';
 import Volume from '~/src/compose/volume';
 
 const defaultContext = {
-	localMode: false,
+	keepVolumes: false,
 	availableImages: [] as Image[],
 	containerIds: {},
 	downloading: [] as string[],

--- a/test/unit/compose/service.spec.ts
+++ b/test/unit/compose/service.spec.ts
@@ -895,7 +895,7 @@ describe('compose/service: unit tests', () => {
 								IPv6Address: '5.6.7.8',
 								LinkLocalIps: ['123.123.123'],
 							},
-							Aliases: ['test', '1123'],
+							Aliases: ['test', '1123', 'deadbeef'],
 						},
 					}).config.networks,
 				).to.deep.equal({
@@ -903,6 +903,7 @@ describe('compose/service: unit tests', () => {
 						ipv4Address: '1.2.3.4',
 						ipv6Address: '5.6.7.8',
 						linkLocalIps: ['123.123.123'],
+						// The container id got removed from the alias list
 						aliases: ['test', '1123'],
 					},
 				});

--- a/test/unit/compose/service.spec.ts
+++ b/test/unit/compose/service.spec.ts
@@ -574,6 +574,80 @@ describe('compose/service: unit tests', () => {
 				expect(svc1.isEqualConfig(svc2, {})).to.be.true;
 			});
 		});
+
+		it('should accept that target network aliases are a subset of current network aliases', async () => {
+			const svc1 = await Service.fromComposeObject(
+				{
+					appId: 1,
+					serviceId: 1,
+					serviceName: 'test',
+					composition: {
+						networks: {
+							test: {
+								aliases: ['hello', 'world'],
+							},
+						},
+					},
+				},
+				{ appName: 'test' } as any,
+			);
+			const svc2 = await Service.fromComposeObject(
+				{
+					appId: 1,
+					serviceId: 1,
+					serviceName: 'test',
+					composition: {
+						networks: {
+							test: {
+								aliases: ['hello', 'sweet', 'world'],
+							},
+						},
+					},
+				},
+				{ appName: 'test' } as any,
+			);
+
+			// All aliases in target service (svc1) are contained in service 2
+			expect(svc2.isEqualConfig(svc1, {})).to.be.true;
+			// But the opposite is not true
+			expect(svc1.isEqualConfig(svc2, {})).to.be.false;
+		});
+
+		it('should accept equal lists of network aliases', async () => {
+			const svc1 = await Service.fromComposeObject(
+				{
+					appId: 1,
+					serviceId: 1,
+					serviceName: 'test',
+					composition: {
+						networks: {
+							test: {
+								aliases: ['hello', 'world'],
+							},
+						},
+					},
+				},
+				{ appName: 'test' } as any,
+			);
+			const svc2 = await Service.fromComposeObject(
+				{
+					appId: 1,
+					serviceId: 1,
+					serviceName: 'test',
+					composition: {
+						networks: {
+							test: {
+								aliases: ['hello', 'world'],
+							},
+						},
+					},
+				},
+				{ appName: 'test' } as any,
+			);
+
+			expect(svc1.isEqualConfig(svc2, {})).to.be.true;
+			expect(svc2.isEqualConfig(svc1, {})).to.be.true;
+		});
 	});
 
 	describe('Feature labels', () => {


### PR DESCRIPTION
This PR contains multiple changes to allow to simplify the interface for the state engine.

As an objective, every operation that performs a change to the device or runtime application should use the target state to do it. For instance, stopping service X is equivalent to taking the current state and passing it as a target to the engine changing the desired state of service X to `running: false`

This was not possible before, because the current state was substantially different from the target state as specific information (like image names) was not available. 

This PR makes the current state returned by `deviceState.getCurrentState()` usable as a target in `applyIntermediateTarget` (this method will probably be renamed, but that's a different issue), and modifies the `doRestart` and `doPurge` actions to use the new interface.

This PR also makes some changes to application manager to make it a bit more agnostic about local mode so it works more closely to the way cloud mode does. This makes it easier to integration test (as integration tests rely on local mode)

Change-type: patch