### PR TITLE
Log uncaught promise exceptions on the app entry

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -136,4 +136,9 @@ process.on('SIGTERM', () => {
 });
 
 const supervisor = new Supervisor();
-supervisor.init();
+supervisor.init().catch((e) => {
+	log.error('Uncaught exception:', e);
+
+	// Terminate the process to avoid leaving the supervisor in a bad state
+	process.exit(1);
+});


### PR DESCRIPTION
Node 15 [changed the way it treats unhandled promise rejections](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V15.md#throw-on-unhandled-rejections---33021) from a warning to a throw. For this reason errors like a corrupt migration directory, that happens when trying to roll back to a previous supervisor version were no longer showing a message but dumping the full minimized code into the journal logs.

This PR adds a catchall on app.ts to log the exception and throw an exit code of 1.

Change-type: patch