### PR TITLE
Do not restart balena-hostname on rename

### DIFF
--- a/src/host-config.ts
+++ b/src/host-config.ts
@@ -185,22 +185,10 @@ async function readHostname() {
 }
 
 async function setHostname(val: string) {
+	// Changing the hostname on config.json will trigger
+	// the OS config-json service to restart the necessary services
+	// so the change gets reflected on containers
 	await config.set({ hostname: val });
-
-	// restart balena-hostname if it is loaded and NOT PartOf config-json.target
-	if (
-		(
-			await Promise.any([
-				dbus.servicePartOf('balena-hostname'),
-				dbus.servicePartOf('resin-hostname'),
-			])
-		).includes('config-json.target') === false
-	) {
-		await Promise.any([
-			dbus.restartService('balena-hostname'),
-			dbus.restartService('resin-hostname'),
-		]);
-	}
 }
 
 export async function get(): Promise<HostConfig> {

--- a/test/integration/host-config.spec.ts
+++ b/test/integration/host-config.spec.ts
@@ -122,15 +122,8 @@ describe('host-config', () => {
 	it('patches hostname', async () => {
 		await hostConfig.patch({ network: { hostname: 'test' } });
 		// /etc/hostname isn't changed until the balena-hostname service
-		// is restarted through dbus, so we verify the change from config.
+		// is restarted by the OS.
 		expect(await config.get('hostname')).to.equal('test');
-	});
-
-	it('skips restarting hostname services if they are part of config-json.target', async () => {
-		(dbus.servicePartOf as SinonStub).resolves('config-json.target');
-		await hostConfig.patch({ network: { hostname: 'newdevice' } });
-		expect(dbus.restartService as SinonStub).to.not.have.been.called;
-		expect(await config.get('hostname')).to.equal('newdevice');
 	});
 
 	it('patches proxy', async () => {


### PR DESCRIPTION
The OS since v2.82.6 will monitor changes to config.json and restart the relevant services to apply the changes. There is no need to trigger restart of the services via the supervisor. Users on older OS versions will need to update their OS or restart the services manually as OS loses support after 2y.

Change-type: patch
Closes: #2160