### PR TITLE
Fix `sw.arch` typo when testing contracts

### DIFF
--- a/test/integration/device-state.spec.ts
+++ b/test/integration/device-state.spec.ts
@@ -408,7 +408,7 @@ describe('device-state', () => {
 												requires: [
 													{
 														type: 'arch.sw',
-														version: 'armv7hf',
+														slug: 'armv7hf',
 													},
 												],
 											},

--- a/test/unit/lib/contracts.spec.ts
+++ b/test/unit/lib/contracts.spec.ts
@@ -169,7 +169,7 @@ describe('lib/contracts', () => {
 									type: 'sw.supervisor',
 									version: `<${supervisorVersionGreater}`,
 								},
-								{ type: 'sw.arch', name: 'amd64' },
+								{ type: 'arch.sw', slug: 'amd64' },
 								{ type: 'hw.device-type', slug: 'intel-nuc' },
 							],
 						},


### PR DESCRIPTION
Change-type: patch