### PR TITLE
Omit CPU id in invalid range

### DIFF
--- a/src/lib/system-info.ts
+++ b/src/lib/system-info.ts
@@ -93,6 +93,13 @@ export async function getSystemId(): Promise<string | undefined> {
 	if (systemId == null) {
 		return;
 	}
+
+	if (/[^\x20-\x7E]/.test(systemId)) {
+		// if the CPU id is not in the character range of 0x20 (SPACE) to 0x7e (~) we drop the CPU ID
+		// this cpu id wouldn't be rendered anyway
+		return;
+	}
+
 	// Always lower case so as not to jump between casing when jumping between eg /proc/device-tree/serial-number and /sys/devices/soc0/serial_number which can return different casing
 	// Lower case was chosen because that is what `/proc/device-tree/serial-number` usually returns and seems to be the more consistently available version
 	return systemId.toLowerCase();

--- a/test/unit/lib/system-info.spec.ts
+++ b/test/unit/lib/system-info.spec.ts
@@ -123,6 +123,18 @@ describe('System information', () => {
 			expect(cpuId).to.equal('1000000001b93f3f');
 		});
 
+		it('system ID is always lower case', async () => {
+			(fs.readFile as SinonStub).resolves('AAAA');
+			const cpuId = await sysInfo.getSystemId();
+			expect(cpuId).to.be.equal('aaaa');
+		});
+
+		it('returns undefined system ID if OS result is invalid', async () => {
+			(fs.readFile as SinonStub).resolves('\x19\x80');
+			const cpuId = await sysInfo.getSystemId();
+			expect(cpuId).to.be.undefined;
+		});
+
 		it('gets system ID from dmidecode if /proc/device-tree/serial-number is not available', async () => {
 			(fs.readFile as SinonStub).rejects('Not found');
 			(fsUtils.exec as SinonStub).resolves({


### PR DESCRIPTION
If the OS query for CPU ID a value in an invalid character range, that can polute the results on the backend. This prevents the supervisor from sending those ids, removing the need for the backend to have to filter.

Change-type: patch