### PR TITLE
Parse container exit error message instead of status to fix Engine-host race

### DIFF
--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -61,7 +61,7 @@ export class Service {
 	public serviceId: number;
 	public imageName: string | null;
 	public containerId: string | null;
-	public exitCode: number | null;
+	public exitErrorMessage: string | null;
 
 	public dependsOn: string[] | null;
 
@@ -504,7 +504,7 @@ export class Service {
 
 		svc.createdAt = new Date(container.Created);
 		svc.containerId = container.Id;
-		svc.exitCode = container.State.ExitCode;
+		svc.exitErrorMessage = container.State.Error;
 
 		let hostname = container.Config.Hostname;
 		if (hostname.length === 12 && _.startsWith(container.Id, hostname)) {

--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -693,22 +693,3 @@ export function dockerMountToServiceMount(
 
 	return mount as LongDefinition;
 }
-
-function isDate(d: unknown): d is Date {
-	return d instanceof Date;
-}
-
-/**
- * @param currentTime Date instance
- * @param seconds time in seconds to check against currentTime
- * @returns
- */
-export function isValidDateAndOlderThan(
-	currentTime: unknown,
-	seconds: number,
-): boolean {
-	if (!isDate(currentTime)) {
-		return false;
-	}
-	return new Date().getTime() - currentTime.getTime() > seconds * 1000;
-}

--- a/test/unit/compose/utils.spec.ts
+++ b/test/unit/compose/utils.spec.ts
@@ -11,33 +11,4 @@ describe('compose/utils', () => {
 			networks: ['test', 'test2'],
 		});
 	});
-
-	it('should return whether a date is valid and older than an interval of seconds', () => {
-		const now = new Date(Date.now());
-		expect(ComposeUtils.isValidDateAndOlderThan(now, 60)).to.equal(false);
-		const time59SecondsAgo = new Date(Date.now() - 59 * 1000);
-		expect(ComposeUtils.isValidDateAndOlderThan(time59SecondsAgo, 60)).to.equal(
-			false,
-		);
-		const time61SecondsAgo = new Date(Date.now() - 61 * 1000);
-		expect(ComposeUtils.isValidDateAndOlderThan(time61SecondsAgo, 60)).to.equal(
-			true,
-		);
-
-		const notDates = [
-			null,
-			undefined,
-			'',
-			'test',
-			123,
-			0,
-			-1,
-			Infinity,
-			NaN,
-			{},
-		];
-		notDates.forEach((n) => {
-			expect(ComposeUtils.isValidDateAndOlderThan(n, 0)).to.equal(false);
-		});
-	});
 });


### PR DESCRIPTION
The previous implementation in #2170 of parsing the container status was too general, because it relied on the mistaken assumption that a container would have a status of `Stopped` if it was manually stopped. This turned out to be untrue, as manually stopped containers were also getting restarted by the Supervisor due to their inspect status of `exited`. With this, parsing the exit message became unavoidable as there are no other clear ways to discern a container that has been manually stopped and shouldn't be started from a container experiencing the Engine-host race condition issue (again, see #2170).

Since we're just parsing the exit error message, we don't need to worry about different behaviors amongst restart policies, as any container with the error message on exit should be started.

Change-type: patch
Closes: #2178