### PR TITLE
backends: Add Jetson Orin NANO custom device-tree support

### DIFF
--- a/src/config/backends/extra-uEnv.ts
+++ b/src/config/backends/extra-uEnv.ts
@@ -63,6 +63,7 @@ export class ExtraUEnv extends ConfigBackend {
 				deviceType.includes('-tx2-nx') ||
 				deviceType.includes('-agx-orin-') ||
 				deviceType.includes('-orin-nx-') ||
+				deviceType.includes('-orin-nano-') ||
 				/imx8mm-var-som/.test(deviceType) ||
 				/imx8mm?-var-dart/.test(deviceType)) &&
 			(await exists(ExtraUEnv.bootConfigPath))

--- a/test/integration/config/extra-uenv.spec.ts
+++ b/test/integration/config/extra-uenv.spec.ts
@@ -233,6 +233,8 @@ const MATCH_TESTS = [
 	{ type: 'jetson-orin-nx-xavier-nx-devkit', supported: true },
 	{ type: 'cti-orin-nx-custom-carrier', supported: true },
 	{ type: 'jetson-orin-agx-nx-xavier-nx-devkit', supported: false },
+	{ type: 'jetson-orin-nano-devkit-nvme', supported: true },
+	{ type: 'jetson-orin-agx-nano-devkit-nvme', supported: false },
 	{ type: 'photon-xavier-nx', supported: false },
 	{ type: 'imx8m-var-dart', supported: true },
 	{ type: 'imx8mm-var-dart', supported: true },


### PR DESCRIPTION
# Description

This PR adds Jetson Orin NANO to the list of devices with custom device-tree support


# How Has This Been Tested?

Modified /mnt/boot/extra_uEnv.txt to add custom_fdt_file=custom.dtb
