### PR TITLE
mount-partitions: do not hardcode partition types

### DIFF
--- a/mount-partitions.sh
+++ b/mount-partitions.sh
@@ -52,17 +52,17 @@ if [ "${TEST}" != 1 ]; then
 fi
 
 # Mounts a device to a path if it's not already mounted.
-# Usage: do_mount DEVICE MOUNT_PATH [FS_TYPE]
+# Usage: do_mount DEVICE MOUNT_PATH
 do_mount() {
     device=$1
     mount_path=$2
-    fs_type=${3:-ext4}
 
     # Create the directory if it doesn't exist
     mkdir -p "${mount_path}"
 
     # Mount the device if it doesn't exist
     if [ "$(mountpoint -n "${mount_path}" | awk '{ print $1 }')" != "${device}" ]; then
+        fs_type=$(lsblk -nlo fstype "${device}")
         mount -t "${fs_type}" "${device}" "${mount_path}"
     fi
 }
@@ -81,20 +81,13 @@ setup_then_mount() {
     partition_label=$1
     target_path=$2
 
-    # Mount as vfat if boot, otherwise ext4
-    if [ "${partition_label}" = "boot" ]; then
-        fs_type="vfat"
-    else    
-        fs_type="ext4"
-    fi
-
     # Try FS label first and partition label as a fallback
     for arg in label partlabel; do
         kname=$(lsblk "/dev/${current_boot_block_device}" -nlo "kname,${arg}" | grep -E "(resin|balena)-${partition_label}" | awk '{print $1}')
         device="/dev/${kname}"
         if [ -b "${device}" ]; then
             echo "INFO: Found device $device on current boot device $current_boot_block_device, using as mount for '(resin|balena)-${partition_label}'."
-            do_mount "${device}" "${target_path}" "${fs_type}"
+            do_mount "${device}" "${target_path}"
             return 0
         fi
     done


### PR DESCRIPTION
Query instead the device for its filesystem type before mounting.

Change-type: patch

*If this is a regression, consider adding it to #1898!*

# Description

Please include a summary of the change and which issue was fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Type of change

Include at least one commit in your PR that marks the change-type. This can be either specified through a Change-type footer, or by adding the change-type as a prefix to the commit, i.e. minor: Add some new feature. This is so the PR can be automatically versioned and a changelog generated for it by using versionist. Check out [semver](https://semver.org/) for a detailed explanation of the different possible change-type values.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
