### PR TITLE
Use `~=` to specify alpine package versions

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,7 +1,7 @@
 ARG ARCH=%%BALENA_ARCH%%
 ARG FATRW_VERSION=0.2.9
-ARG NODE="nodejs<19"
-ARG NPM="npm<10"
+ARG NODE="nodejs~=18"
+ARG NPM="npm~=9"
 ARG ALPINE_VERSION="3.18"
 
 ###################################################


### PR DESCRIPTION
Alpine allows the `~=` syntax to match a part of the package version when installing. In this case we want to use it to specify node and npm major versions

Change-type: patch