### PR TITLE
Use native `structuredClone` instead of _.cloneDeep

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "systeminformation": "^5.6.10"
   },
   "engines": {
-    "node": ">=16.17.0",
-    "npm": ">=8.15.0"
+    "node": ">=18.18.0",
+    "npm": ">=9.8.1"
   },
   "devDependencies": {
     "@balena/contrato": "^0.6.0",

--- a/src/api-binder/index.ts
+++ b/src/api-binder/index.ts
@@ -528,7 +528,7 @@ export const initialized = _.once(async () => {
 	}
 
 	const baseUrl = url.resolve(apiEndpoint, '/v6/');
-	const passthrough = _.cloneDeep(await request.getRequestOptions());
+	const passthrough = structuredClone(await request.getRequestOptions());
 	passthrough.headers = passthrough.headers != null ? passthrough.headers : {};
 	passthrough.headers.Authorization = `Bearer ${currentApiKey}`;
 	balenaApi = new PinejsClientRequest({

--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -546,7 +546,7 @@ export async function setTarget(
 	// filter those out and add the target state to the database
 	const contractViolators: { [appName: string]: string[] } = {};
 	const fulfilledContracts = validateTargetContracts(apps);
-	const filteredApps = _.cloneDeep(apps);
+	const filteredApps = structuredClone(apps);
 	_.each(
 		fulfilledContracts,
 		(

--- a/src/compose/network.ts
+++ b/src/compose/network.ts
@@ -261,7 +261,7 @@ export class Network {
 		// default or generated values)
 		let configToCompare = this.config;
 		if (network.config.ipam.config.length === 0) {
-			configToCompare = _.cloneDeep(this.config);
+			configToCompare = structuredClone(this.config);
 			configToCompare.ipam.config = [];
 		}
 
@@ -270,7 +270,7 @@ export class Network {
 		// Any ipam config will be included in the network, but not applied
 		// in the host's networking layer.
 		if (network.config.configOnly) {
-			configToCompare = _.cloneDeep(this.config);
+			configToCompare = structuredClone(this.config);
 			configToCompare.driver = network.config.driver;
 		}
 

--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -30,7 +30,7 @@ export function camelCaseConfig(
 	// Networks can either be an object or array, but given _.isObject
 	// returns true for an array, we check the other way
 	if (!_.isArray(config.networks)) {
-		const networksTmp = _.cloneDeep(config.networks);
+		const networksTmp = structuredClone(config.networks);
 		_.each(networksTmp, (v, k) => {
 			config.networks[k] = _.mapKeys(v, (_v, key) => _.camelCase(key));
 		});

--- a/src/device-config.ts
+++ b/src/device-config.ts
@@ -389,7 +389,7 @@ export function bootConfigChangeRequired(
 		const SPECIAL_CASE = 'configuration'; // ODMDATA Mode for TX2 devices
 		if (!(SPECIAL_CASE in targetBootConfig)) {
 			// Create a copy to modify
-			const targetCopy = _.cloneDeep(targetBootConfig);
+			const targetCopy = structuredClone(targetBootConfig);
 			// Add current value to simulate if the value was set in the cloud on provision
 			targetCopy[SPECIAL_CASE] = currentBootConfig[SPECIAL_CASE];
 			if (_.isEqual(targetCopy, currentBootConfig)) {

--- a/src/device-state/target-state.ts
+++ b/src/device-state/target-state.ts
@@ -64,7 +64,7 @@ const emitTargetState = (
 		// CachedResponse has not been emitted before so emit as an update
 		emitter.emit(
 			'target-state-update',
-			_.cloneDeep(cachedResponse.body),
+			structuredClone(cachedResponse.body),
 			force,
 			isFromApi,
 		);
@@ -201,7 +201,7 @@ const poll = async (
  */
 export const get = async (): Promise<TargetState> => {
 	await update();
-	return _.cloneDeep(cache.body);
+	return structuredClone(cache.body);
 };
 
 /**

--- a/src/event-tracker.ts
+++ b/src/event-tracker.ts
@@ -24,7 +24,7 @@ export async function track(
 		properties = { error: properties };
 	}
 
-	properties = _.cloneDeep(properties);
+	properties = structuredClone(properties);
 	if (properties.error instanceof Error) {
 		// Format the error for printing, to avoid display as { }
 		properties.error = {


### PR DESCRIPTION
Now that we're on Node 18 with 14.13.0, we can use native `structuredClone`, which memory tests have shown to have better performance than lodash's `_.cloneDeep`.