### PR TITLE
Add tmpfs for /mnt/root/tmp in test env

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -25,6 +25,7 @@ services:
       - ./test/lib/wait-for-it.sh:/wait-for-it.sh
     tmpfs:
       - /data # sqlite3 database
+      - /mnt/root/tmp
 
   # The service setup
   mock-systemd:


### PR DESCRIPTION
This is to prevent the target state cache from getting written to host during tests.

Change-type: patch