### PR TITLE
Do not expose ports from image if service network mode

### DIFF
--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -346,7 +346,9 @@ export class Service {
 			'Config.ExposedPorts',
 			{},
 		);
-		expose = expose.concat(_.keys(imageExposedPorts));
+		if (!serviceNetworkMode) {
+			expose = expose.concat(_.keys(imageExposedPorts));
+		}
 		// Also add any exposed ports which are implied from the portMaps
 		const exposedFromPortMappings = _.flatMap(portMaps, (port) =>
 			port.toExposedPortArray(),

--- a/test/unit/compose/service.spec.ts
+++ b/test/unit/compose/service.spec.ts
@@ -1082,6 +1082,35 @@ describe('compose/service: unit tests', () => {
 			return expect(dockerSvc.isEqualConfig(composeSvc, { test: 'qwerty' })).to
 				.be.false;
 		});
+
+		it('should omit exposing ports from the source image', async () => {
+			const s = await Service.fromComposeObject(
+				{
+					appId: '1234',
+					serviceName: 'foo',
+					releaseId: 2,
+					serviceId: 3,
+					imageId: 4,
+					composition: {
+						network_mode: 'service: test',
+						expose: ['433/tcp'],
+					},
+				},
+				{
+					appName: 'test',
+					imageInfo: {
+						Config: {
+							ExposedPorts: {
+								'8080/tcp': {},
+							},
+						},
+					},
+				} as any,
+			);
+
+			// Only explicitely exposed ports are set if network_mode: service is used
+			expect(s.config.expose).to.deep.equal(['433/tcp']);
+		});
 	});
 
 	describe('Security options', () => {


### PR DESCRIPTION
The supervisor exposes ports configured using the `EXPOSE` directive in the dockerfile when configuring the container for runtime. This can cause issues if using `network_mode: service:<service name>` as the expose configuration is not compatible with that network mode. This fix now skips image exposed ports for that particular network mode.

Change-type: patch