### PR TITLE
Revert "Do not expose ports from image if service network mode"

### DIFF
--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -346,9 +346,7 @@ export class Service {
 			'Config.ExposedPorts',
 			{},
 		);
-		if (!serviceNetworkMode) {
-			expose = expose.concat(_.keys(imageExposedPorts));
-		}
+		expose = expose.concat(_.keys(imageExposedPorts));
 		// Also add any exposed ports which are implied from the portMaps
 		const exposedFromPortMappings = _.flatMap(portMaps, (port) =>
 			port.toExposedPortArray(),

--- a/test/unit/compose/service.spec.ts
+++ b/test/unit/compose/service.spec.ts
@@ -1082,35 +1082,6 @@ describe('compose/service: unit tests', () => {
 			return expect(dockerSvc.isEqualConfig(composeSvc, { test: 'qwerty' })).to
 				.be.false;
 		});
-
-		it('should omit exposing ports from the source image', async () => {
-			const s = await Service.fromComposeObject(
-				{
-					appId: '1234',
-					serviceName: 'foo',
-					releaseId: 2,
-					serviceId: 3,
-					imageId: 4,
-					composition: {
-						network_mode: 'service: test',
-						expose: ['433/tcp'],
-					},
-				},
-				{
-					appName: 'test',
-					imageInfo: {
-						Config: {
-							ExposedPorts: {
-								'8080/tcp': {},
-							},
-						},
-					},
-				} as any,
-			);
-
-			// Only explicitely exposed ports are set if network_mode: service is used
-			expect(s.config.expose).to.deep.equal(['433/tcp']);
-		});
 	});
 
 	describe('Security options', () => {


### PR DESCRIPTION
This reverts commit 0c7bad779291e15e419166a2c66c2a21dd06aa83, as that change causes a service restart loop. The supervisor cannot distinguish between ports exposed via the `EXPOSE` directive and the docker-compose `expose` property. Because of this, in the case of `network-mode: service:<...>` the current state and target state never match, leading to a service restart loop.

Change-type: patch