### PR TITLE
Ignore `expose` service compose configuration

### DIFF
--- a/src/compose/ports.ts
+++ b/src/compose/ports.ts
@@ -15,7 +15,6 @@ export interface PortBindings {
 }
 
 export interface DockerPortOptions {
-	exposedPorts: Dictionary<{}>;
 	portBindings: PortBindings;
 }
 
@@ -49,31 +48,17 @@ export class PortMap {
 			this.ports.externalEnd,
 		);
 
-		const exposedPorts: { [key: string]: {} } = {};
 		const portBindings: PortBindings = {};
 
 		_.zipWith(internalRange, externalRange, (internal, external) => {
-			exposedPorts[`${internal}/${this.ports.protocol}`] = {};
-
 			portBindings[`${internal}/${this.ports.protocol}`] = [
 				{ HostIp: this.ports.host, HostPort: external.toString() },
 			];
 		});
 
 		return {
-			exposedPorts,
 			portBindings,
 		};
-	}
-
-	public toExposedPortArray(): string[] {
-		const internalRange = this.generatePortRange(
-			this.ports.internalStart,
-			this.ports.internalEnd,
-		);
-		return _.map(internalRange, (internal) => {
-			return `${internal}/${this.ports.protocol}`;
-		});
 	}
 
 	/**

--- a/src/compose/sanitise.ts
+++ b/src/compose/sanitise.ts
@@ -18,7 +18,6 @@ const supportedComposeFields = [
 	'tmpfs',
 	'entrypoint',
 	'environment',
-	'expose',
 	'extraHosts',
 	'groupAdd',
 	'healthcheck',

--- a/src/compose/types/service.ts
+++ b/src/compose/types/service.ts
@@ -179,7 +179,6 @@ export interface ServiceComposeConfig {
 	tmpfs?: string | string[];
 	entrypoint?: string | string[];
 	environment?: { [envVarName: string]: string };
-	expose?: string[];
 	extraHosts?: string[];
 	groupAdd?: string[];
 	healthcheck?: ComposeHealthcheck;
@@ -239,7 +238,6 @@ export interface ServiceConfig {
 	tmpfs: string[];
 	entrypoint: string | string[];
 	environment: { [envVarName: string]: string };
-	expose: string[];
 	extraHosts: string[];
 	groupAdd: string[];
 	healthcheck: ServiceHealthcheck;
@@ -295,7 +293,6 @@ export type ServiceConfigArrayField =
 	| 'dns'
 	| 'dnsSearch'
 	| 'dnsOpt'
-	| 'expose'
 	| 'tmpfs'
 	| 'extraHosts'
 	| 'ulimitsArray'

--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -288,13 +288,6 @@ export function getUser(
 	return user != null ? user : _.get(imageInfo, 'Config.User', '');
 }
 
-export function sanitiseExposeFromCompose(portStr: string): string {
-	if (/^[0-9]*$/.test(portStr)) {
-		return `${portStr}/tcp`;
-	}
-	return portStr;
-}
-
 export function formatDevice(deviceStr: string): DockerDevice {
 	const [pathOnHost, ...parts] = deviceStr.split(':');
 	let [pathInContainer, cgroup] = parts;

--- a/test/unit/compose/ports.spec.ts
+++ b/test/unit/compose/ports.spec.ts
@@ -98,9 +98,6 @@ describe('compose/ports', function () {
 	describe('toDockerOpts', function () {
 		it('should correctly generate docker options', () =>
 			expect(new PortMapPublic('80').toDockerOpts()).to.deep.equal({
-				exposedPorts: {
-					'80/tcp': {},
-				},
 				portBindings: {
 					'80/tcp': [{ HostIp: '', HostPort: '80' }],
 				},
@@ -108,14 +105,6 @@ describe('compose/ports', function () {
 
 		it('should correctly generate docker options for a port range', () =>
 			expect(new PortMapPublic('80-85').toDockerOpts()).to.deep.equal({
-				exposedPorts: {
-					'80/tcp': {},
-					'81/tcp': {},
-					'82/tcp': {},
-					'83/tcp': {},
-					'84/tcp': {},
-					'85/tcp': {},
-				},
 				portBindings: {
 					'80/tcp': [{ HostIp: '', HostPort: '80' }],
 					'81/tcp': [{ HostIp: '', HostPort: '81' }],

--- a/test/unit/compose/service.spec.ts
+++ b/test/unit/compose/service.spec.ts
@@ -129,7 +129,7 @@ describe('compose/service: unit tests', () => {
 				} as any,
 			);
 
-			const ports = (s as any).generateExposeAndPorts();
+			const ports = (s as any).generatePortBindings();
 			expect(ports.portBindings).to.deep.equal({
 				'2344/tcp': [
 					{
@@ -150,15 +150,6 @@ describe('compose/service: unit tests', () => {
 					},
 				],
 			});
-			expect(ports.exposedPorts).to.deep.equal({
-				'1000/tcp': {},
-				'243/udp': {},
-				'2344/tcp': {},
-				'2354/tcp': {},
-				'2367/udp': {},
-				'53/tcp': {},
-				'53/udp': {},
-			});
 		});
 
 		it('correctly handles port ranges', async () => {
@@ -177,7 +168,7 @@ describe('compose/service: unit tests', () => {
 				{ appName: 'test' } as any,
 			);
 
-			const ports = (s as any).generateExposeAndPorts();
+			const ports = (s as any).generatePortBindings();
 			expect(ports.portBindings).to.deep.equal({
 				'2000/tcp': [
 					{
@@ -204,15 +195,6 @@ describe('compose/service: unit tests', () => {
 					},
 				],
 			});
-
-			expect(ports.exposedPorts).to.deep.equal({
-				'1000/tcp': {},
-				'2000/tcp': {},
-				'2001/tcp': {},
-				'2002/tcp': {},
-				'2003/tcp': {},
-				'243/udp': {},
-			});
 		});
 
 		it('should correctly handle large port ranges', async function () {
@@ -231,10 +213,10 @@ describe('compose/service: unit tests', () => {
 				{ appName: 'test' } as any,
 			);
 
-			expect((s as any).generateExposeAndPorts()).to.not.throw;
+			expect((s as any).generatePortBindings).to.not.throw;
 		});
 
-		it('should correctly report implied exposed ports from portMappings', async () => {
+		it('should not report implied exposed ports from portMappings', async () => {
 			const service = await Service.fromComposeObject(
 				{
 					appId: 123456,
@@ -247,9 +229,7 @@ describe('compose/service: unit tests', () => {
 				{ appName: 'test' } as any,
 			);
 
-			expect(service.config)
-				.to.have.property('expose')
-				.that.deep.equals(['80/tcp', '100/tcp']);
+			expect(service.config).to.not.have.property('expose');
 		});
 
 		it('should correctly handle spaces in volume definitions', async () => {


### PR DESCRIPTION
The docker EXPOSE directive and corresponding docker-compose `expose`
service configuration serves as documentation/metadata that a container
listens on a certain port that may be used for service discovery but it doesn't
have any real impact on the ability for
other containers on the same network to access the exposed service via
the port. In newer engine implementations, this property may conflict
with other network configurations, and prevent the container from being
started by the docker engine (see https://github.com/balena-os/balena-supervisor/issues/2211).

This PR removes code that would manage the expose property and takes the
property out of the whitelist. A composition with the `expose` property
will result in the log message `Ignoring unsupported or unknown compose fields: expose`.

While this change should not have operational impact, it still removes
a previously supported configuration and as such there is a chance of it
being a breaking change for some applications. For this reason it is
being published as a new major version.

Change-type: major
Closes: https://github.com/balena-os/balena-supervisor/issues/2211