### PR TITLE
Expose ports from port mappings on services

### DIFF
--- a/src/compose/ports.ts
+++ b/src/compose/ports.ts
@@ -15,6 +15,7 @@ export interface PortBindings {
 }
 
 export interface DockerPortOptions {
+	exposedPorts: Dictionary<{}>;
 	portBindings: PortBindings;
 }
 
@@ -48,15 +49,19 @@ export class PortMap {
 			this.ports.externalEnd,
 		);
 
+		const exposedPorts: { [key: string]: {} } = {};
 		const portBindings: PortBindings = {};
 
 		_.zipWith(internalRange, externalRange, (internal, external) => {
+			exposedPorts[`${internal}/${this.ports.protocol}`] = {};
+
 			portBindings[`${internal}/${this.ports.protocol}`] = [
 				{ HostIp: this.ports.host, HostPort: external.toString() },
 			];
 		});
 
 		return {
+			exposedPorts,
 			portBindings,
 		};
 	}

--- a/test/unit/compose/ports.spec.ts
+++ b/test/unit/compose/ports.spec.ts
@@ -98,6 +98,9 @@ describe('compose/ports', function () {
 	describe('toDockerOpts', function () {
 		it('should correctly generate docker options', () =>
 			expect(new PortMapPublic('80').toDockerOpts()).to.deep.equal({
+				exposedPorts: {
+					'80/tcp': {},
+				},
 				portBindings: {
 					'80/tcp': [{ HostIp: '', HostPort: '80' }],
 				},
@@ -105,6 +108,14 @@ describe('compose/ports', function () {
 
 		it('should correctly generate docker options for a port range', () =>
 			expect(new PortMapPublic('80-85').toDockerOpts()).to.deep.equal({
+				exposedPorts: {
+					'80/tcp': {},
+					'81/tcp': {},
+					'82/tcp': {},
+					'83/tcp': {},
+					'84/tcp': {},
+					'85/tcp': {},
+				},
 				portBindings: {
 					'80/tcp': [{ HostIp: '', HostPort: '80' }],
 					'81/tcp': [{ HostIp: '', HostPort: '81' }],


### PR DESCRIPTION
PR #2217 removed the expose configuration but also caused a regresion where ports set via the `ports` configuration would no longer get exposed to the host, despite portmappings being set. This fixes that issue by exposing only those ports comming from port mappings.

Change-type: patch