### PR TITLE
Set applyInProgress to true while applying intermediate state

### DIFF
--- a/src/device-state.ts
+++ b/src/device-state.ts
@@ -890,6 +890,7 @@ export async function applyIntermediateTarget(
 	return pausingApply(async () => {
 		// TODO: Make sure we don't accidentally overwrite this
 		intermediateTarget = intermediate;
+		applyInProgress = true;
 		return applyTarget({
 			intermediate: true,
 			force,
@@ -897,6 +898,7 @@ export async function applyIntermediateTarget(
 			keepVolumes,
 		}).then(() => {
 			intermediateTarget = null;
+			applyInProgress = false;
 		});
 	});
 }


### PR DESCRIPTION
Intermediate state is utilized when executing device actions such as a volume purge. It's a type of state apply, but despite that, applyInProgress is not true.

Change-type: patch