### PR TITLE
Apply update strategies app-wide

### DIFF
--- a/src/compose/update-strategies.ts
+++ b/src/compose/update-strategies.ts
@@ -1,12 +1,12 @@
 import * as imageManager from './images';
 import Service from './service';
-
-import { InternalInconsistencyError } from '../lib/errors';
 import { CompositionStep, generateStep } from './composition-steps';
+import { InternalInconsistencyError } from '../lib/errors';
+import { checkString } from '../lib/validation';
 
 export interface StrategyContext {
 	current: Service;
-	target: Service;
+	target?: Service;
 	needsDownload: boolean;
 	dependenciesMetForStart: boolean;
 	dependenciesMetForKill: boolean;
@@ -19,39 +19,57 @@ export function getStepsFromStrategy(
 ): CompositionStep {
 	switch (strategy) {
 		case 'download-then-kill':
-			if (context.needsDownload) {
+			if (context.needsDownload && context.target) {
 				return generateStep('fetch', {
 					image: imageManager.imageFromService(context.target),
-					serviceName: context.target.serviceName!,
+					serviceName: context.target.serviceName,
 				});
 			} else if (context.dependenciesMetForKill) {
 				// We only kill when dependencies are already met, so that we minimize downtime
 				return generateStep('kill', { current: context.current });
 			} else {
-				return { action: 'noop' };
+				return generateStep('noop', {});
 			}
 		case 'kill-then-download':
 		case 'delete-then-download':
 			return generateStep('kill', { current: context.current });
 		case 'hand-over':
-			if (context.needsDownload) {
+			if (context.needsDownload && context.target) {
 				return generateStep('fetch', {
 					image: imageManager.imageFromService(context.target),
-					serviceName: context.target.serviceName!,
+					serviceName: context.target.serviceName,
 				});
 			} else if (context.needsSpecialKill && context.dependenciesMetForKill) {
 				return generateStep('kill', { current: context.current });
-			} else if (context.dependenciesMetForStart) {
+			} else if (context.dependenciesMetForStart && context.target) {
 				return generateStep('handover', {
 					current: context.current,
 					target: context.target,
 				});
 			} else {
-				return { action: 'noop' };
+				return generateStep('noop', {});
 			}
 		default:
 			throw new InternalInconsistencyError(
 				`Invalid update strategy: ${strategy}`,
 			);
 	}
+}
+
+export function getStrategyFromService(svc: Service): string {
+	let strategy =
+		checkString(svc.config.labels['io.balena.update.strategy']) || '';
+
+	const validStrategies = [
+		'download-then-kill',
+		'kill-then-download',
+		'delete-then-download',
+		'hand-over',
+	];
+
+	if (!validStrategies.includes(strategy)) {
+		strategy = 'download-then-kill';
+	}
+
+	return strategy;
 }


### PR DESCRIPTION
The Supervisor's state engine has some edge cases where it does not respect the update strategy of the app. These edge cases relate to a release update which removes an old service and also adds a new service. This PR fixes those edge cases.

See: https://balena.fibery.io/Work/Improvement/Supervisor-improved-multi-container-updates-1329
Change-type: patch
Closes: #2095
Signed-off-by: Christina Ying Wang <christina@balena.io>