### PR TITLE
Patch config.txt backend to return array configs correctly

### DIFF
--- a/src/config/backends/config-txt.ts
+++ b/src/config/backends/config-txt.ts
@@ -157,6 +157,9 @@ export class ConfigTxt extends ConfigBackend {
 						// Otherwise push the new value to the array
 						const arrayConf = conf[key] == null ? [] : conf[key]!;
 						arrayConf.push(value);
+						if (conf[key] == null) {
+							conf[key] = arrayConf;
+						}
 					}
 				}
 				continue;

--- a/test/integration/config/config-txt.spec.ts
+++ b/test/integration/config/config-txt.spec.ts
@@ -17,6 +17,8 @@ describe('config/config-txt', () => {
 					dtoverlay=ads7846
 					enable_uart=1
 					avoid_warnings=1
+					gpio=8=pd
+					gpio=17=op,dh
 					gpu_mem=16
 					hdmi_force_hotplug:1=1
 					dtoverlay=lirc-rpi,gpio_out_pin=17,gpio_in_pin=13
@@ -34,6 +36,7 @@ describe('config/config-txt', () => {
 			],
 			enable_uart: '1',
 			avoid_warnings: '1',
+			gpio: ['8=pd', '17=op,dh'],
 			gpu_mem: '16',
 			initramfs: 'initramf.gz 0x00800000',
 			'hdmi_force_hotplug:1': '1',


### PR DESCRIPTION
Previously, getBootConfig() of the config.txt backend was omitting array configurations such as gpio settings, thus resulting in the SV mistakenly assuming that boot config had not been applied, since gpio would not be in current config.txt config but would be in target config. This resulted in SV entering an infinite loop of attempting to apply the gpio config when it wasn't necessary.

Change-type: patch