### PR TITLE
Patch default dtparam handling in config.txt

### DIFF
--- a/src/config/backends/config-txt.ts
+++ b/src/config/backends/config-txt.ts
@@ -40,7 +40,19 @@ function isBaseParam(dtparam: string): boolean {
 
 	// These hardcoded params correspond to the params set
 	// in the default config.txt provided by balena for pi devices
-	if (['audio', 'i2c_arm', 'spi'].includes(key)) {
+	// See: https://www.raspberrypi.com/documentation/computers/configuration.html#part3.3
+	if (
+		[
+			'audio',
+			'spi',
+			'i2c',
+			'i2c_arm',
+			'i2c_vc',
+			'i2c_baudrate',
+			'i2c_arm_baudrate',
+			'i2c_vc_baudrate',
+		].includes(key)
+	) {
 		return true;
 	}
 	return false;

--- a/test/integration/config/config-txt.spec.ts
+++ b/test/integration/config/config-txt.spec.ts
@@ -89,10 +89,15 @@ describe('config/config-txt', () => {
 					dtparam=gpio_out_pin=17
 					enable_uart=1
 					avoid_warnings=1
-					dtparam=i2c_arm=on
 					dtparam=spi=on
 					dtparam=audio=on
+					dtparam=i2c=on
+					dtparam=i2c_arm=on
+					dtparam=i2c_vc=on
+					dtparam=i2c_baudrate=100000
+					dtparam=i2c_arm_baudrate=100000
 					dtoverlay=ads7846
+					dtparam=i2c_vc_baudrate=100000
 					gpu_mem=16
 					hdmi_force_hotplug:1=1
 					`,
@@ -102,7 +107,16 @@ describe('config/config-txt', () => {
 
 		// Will try to parse /test/data/mnt/boot/config.txt
 		await expect(configTxt.getBootConfig()).to.eventually.deep.equal({
-			dtparam: ['i2c_arm=on', 'spi=on', 'audio=on'],
+			dtparam: [
+				'spi=on',
+				'audio=on',
+				'i2c=on',
+				'i2c_arm=on',
+				'i2c_vc=on',
+				'i2c_baudrate=100000',
+				'i2c_arm_baudrate=100000',
+				'i2c_vc_baudrate=100000',
+			],
 			dtoverlay: [
 				'lirc-rpi,gpio_out_pin=17,gpio_in_pin=13,gpio_out_pin=17',
 				'ads7846',


### PR DESCRIPTION
This commit completes the list of default / board-wide dtparams to include some `baudrate` and `vc` i2c params.

Change-type: patch