### PR TITLE
Fix support for rsync deltas

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -15,6 +15,19 @@ source ./mount-partitions.sh
 [ -d "${ROOT_MOUNTPOINT}"/tmp/balena-supervisor ] ||
 	mkdir -p "${ROOT_MOUNTPOINT}"/tmp/balena-supervisor
 
+# If DOCKER_ROOT isn't set then default it
+DOCKER_LIB_PATH="/var/lib/docker"
+if [ -z "${DOCKER_ROOT}" ]; then
+	DOCKER_ROOT="${ROOT_MOUNTPOINT}${DOCKER_LIB_PATH}"
+fi
+
+# Mount the DOCKER_ROOT path equivalent in the container fs
+# this is necessary as long as the supervisor still has support
+# for rsync deltas
+if [ ! -d "${DOCKER_LIB_PATH}" ]; then
+	ln -s "${DOCKER_ROOT}" "${DOCKER_LIB_PATH}"
+fi
+
 # Include self-signed CAs, should they exist
 if [ -n "${BALENA_ROOT_CA}" ]; then
 	if [ ! -e '/etc/ssl/certs/balenaRootCA.pem' ]; then


### PR DESCRIPTION
Rsync (v2) deltas have been broken since [Supervisor v14](https://github.com/balena-os/balena-supervisor/commit/460c3ba0aab31d18a02e3f5dda1838691768c494). While considered legacy, they are still used by a few customers with devices running OS < 2.47.1. This should fix v2 delta support for those devices until we can completely remove rsync deltas from the codebase

Change-type: patch