### PR TITLE
Update Node to v20

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,8 +1,8 @@
 ARG ARCH=%%BALENA_ARCH%%
 ARG FATRW_VERSION=0.2.9
-ARG NODE="nodejs~=18"
-ARG NPM="npm~=9"
-ARG ALPINE_VERSION="3.18"
+ARG NODE="nodejs~=20"
+ARG NPM="npm~=10"
+ARG ALPINE_VERSION="3.19"
 
 ###################################################
 # Build the supervisor dependencies

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Here's a few guidelines to make the process easier for everyone involved.
 
 These are the system requirements for developing and testing the balenaSupervisor on a local machine
 
-- [Node.js](https://nodejs.org/en) v18 or latest
+- [Node.js](https://nodejs.org/en) v20 or latest
 - [Rust](https://www.rust-lang.org/) v1.64 or latest for installing the [@balena/systemd](https://www.npmjs.com/package/@balena/systemd) NPM package.
 - If developing on an architecture not supported by default by [node-sqlite3](https://github.com/TryGhost/node-sqlite3#prebuilt-binaries), a C++ compiler and linker are also required, plus the libsqlite development headers.
 
@@ -195,7 +195,7 @@ To run type checks, and unit tests, you can use:
 npm run test
 ```
 
-The supervisor runs on Node v12.16.2, so using that specific
+The supervisor runs on Node v20, so using that specific
 version will ensure tests run in the same environment as
 production.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@types/mocha": "^8.2.3",
         "@types/mock-fs": "^4.13.1",
         "@types/morgan": "^1.9.3",
-        "@types/node": "^18.11.7",
+        "@types/node": "^20.11.24",
         "@types/request": "^2.48.8",
         "@types/rewire": "^2.5.28",
         "@types/rimraf": "^2.0.5",
@@ -2154,10 +2154,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
-      "integrity": "sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==",
-      "dev": true
+      "version": "20.11.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
+      "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/object-hash": {
       "version": "2.1.0",
@@ -15079,6 +15082,12 @@
         "debug": "^2.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -17826,10 +17835,13 @@
       }
     },
     "@types/node": {
-      "version": "18.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
-      "integrity": "sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==",
-      "dev": true
+      "version": "20.11.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
+      "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/object-hash": {
       "version": "2.1.0",
@@ -27768,6 +27780,12 @@
       "requires": {
         "debug": "^2.2.0"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "unique-filename": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       "devDependencies": {
         "@balena/contrato": "^0.6.0",
         "@balena/es-version": "^1.0.1",
-        "@balena/happy-eyeballs": "0.0.6",
         "@balena/lint": "^7.3.0",
         "@types/bluebird": "^3.5.37",
         "@types/chai": "^4.3.3",
@@ -117,8 +116,8 @@
         "yargs": "^15.4.1"
       },
       "engines": {
-        "node": "^18.18.0",
-        "npm": "^9.8.1"
+        "node": ">=20 <21",
+        "npm": ">=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -618,22 +617,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@balena/es-version/-/es-version-1.0.1.tgz",
       "integrity": "sha512-3hS6695vmZcKm+UX9W+4xVSYIW56OIjq8wLybKZsNoMDLAXei9HnbhnVLsbqWhqATrRKHy19onjJQHL/AfcpFA==",
-      "dev": true
-    },
-    "node_modules/@balena/happy-eyeballs": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@balena/happy-eyeballs/-/happy-eyeballs-0.0.6.tgz",
-      "integrity": "sha512-aT/m3q5fB+EwpqaFgbO42E4JTIAETvO4judob4UHUivq+xdB5KIXkG+NfG6LpFh/SWzxqqpiDNnmi6zF4lPO+g==",
-      "dev": true,
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@balena/happy-eyeballs/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
     },
     "node_modules/@balena/lint": {
@@ -2977,18 +2960,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -6783,15 +6754,6 @@
         "split": "0.3",
         "stream-combiner": "~0.0.4",
         "through": "~2.3.1"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/events": {
@@ -16633,24 +16595,6 @@
       "integrity": "sha512-3hS6695vmZcKm+UX9W+4xVSYIW56OIjq8wLybKZsNoMDLAXei9HnbhnVLsbqWhqATrRKHy19onjJQHL/AfcpFA==",
       "dev": true
     },
-    "@balena/happy-eyeballs": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@balena/happy-eyeballs/-/happy-eyeballs-0.0.6.tgz",
-      "integrity": "sha512-aT/m3q5fB+EwpqaFgbO42E4JTIAETvO4judob4UHUivq+xdB5KIXkG+NfG6LpFh/SWzxqqpiDNnmi6zF4lPO+g==",
-      "dev": true,
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-          "dev": true
-        }
-      }
-    },
     "@balena/lint": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@balena/lint/-/lint-7.3.0.tgz",
@@ -18512,15 +18456,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
     },
     "accepts": {
       "version": "1.3.7",
@@ -21498,12 +21433,6 @@
         "stream-combiner": "~0.0.4",
         "through": "~2.3.1"
       }
-    },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
     },
     "events": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "sqlite3": "^5.1.6"
   },
   "engines": {
-    "node": "^18.18.0",
-    "npm": "^9.8.1"
+    "node": ">=20 <21",
+    "npm": ">=10"
   },
   "devDependencies": {
     "@balena/contrato": "^0.6.0",
@@ -60,7 +60,7 @@
     "@types/mocha": "^8.2.3",
     "@types/mock-fs": "^4.13.1",
     "@types/morgan": "^1.9.3",
-    "@types/node": "^18.11.7",
+    "@types/node": "^20.11.24",
     "@types/request": "^2.48.8",
     "@types/rewire": "^2.5.28",
     "@types/rimraf": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "devDependencies": {
     "@balena/contrato": "^0.6.0",
     "@balena/es-version": "^1.0.1",
-    "@balena/happy-eyeballs": "0.0.6",
     "@balena/lint": "^7.3.0",
     "@types/bluebird": "^3.5.37",
     "@types/chai": "^4.3.3",

--- a/src/app.ts
+++ b/src/app.ts
@@ -142,7 +142,6 @@ async function mdnsLookup(
 	};
 })();
 
-import '@balena/happy-eyeballs/eye-patch';
 import Supervisor from './supervisor';
 import process from 'process';
 import log from './lib/supervisor-console';

--- a/src/logging/balena-backend.ts
+++ b/src/logging/balena-backend.ts
@@ -31,7 +31,7 @@ export class BalenaLogBackend extends LogBackend {
 	private gzip: zlib.Gzip | null = null;
 	private opts: Options;
 	private stream: stream.PassThrough;
-	private timeout: NodeJS.Timer;
+	private timeout: NodeJS.Timeout;
 
 	public initialised = false;
 


### PR DESCRIPTION
This updates the supervisor runtime to latest Node LTS version. There are no breaking changes related to this bump.

Change-type: patch