### PR TITLE
Pin iptables to 1.8.9 (legacy)

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -58,7 +58,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends systemd
 COPY ./build-utils/setup-journal.sh /
 RUN /setup-journal.sh
 
-
 ###################################################
 # Extra dependencies. This uses alpine 3.11 as the
 # procmail package was removed on 3.12
@@ -92,13 +91,17 @@ COPY mount-partitions.sh .
 # Runtime dependencies
 RUN apk add --update --no-cache \
 	$NODE \
-	iptables \
-	ip6tables \
 	rsync \
 	dbus \
 	dmidecode \
 	sqlite-libs \
 	lsblk
+
+# Iptables should be pinned to 1.8.9 (legacy) as balenaOS still uses iptables-legacy
+RUN apk add --update --no-cache \
+	--repository=http://dl-cdn.alpinelinux.org/alpine/v3.18/main \
+	iptables~=1.8.9 \
+	ip6tables~=1.8.9
 
 ARG ARCH
 ARG VERSION=master


### PR DESCRIPTION
With Alpine 3.19, iptables gets bumped to 1.8.10 which uses nftables. The host OS still uses iptables 1.8.7 (legacy), and the compatibility of legacy & nftables is questionable. At the minimum, nftables-created rules don't appear when running iptables -L using legacy iptables, and this is confusing for users. Worst case scenario, rules made with iptables-nftables don't apply at all, leaving the device vulnerable.

See: https://balena.zulipchat.com/#narrow/stream/345889-balena-io.2Fos/topic/iptables.20host.20vs.2E.20nftables.20Supervisor
Change-type: patch

Tested by running on a device using `npm run sync` and verifying iptables version using `iptables -V`. Also checked rules were still applied and iptables otherwise functions properly using `iptables -L`, both from host and in Supervisor container.