### PR TITLE
Increase the timeout for auto select family to 5000ms to avoid issues

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,10 @@ import { set } from '@balena/es-version';
 // Set the desired es version for downstream modules that support it, before we import any
 set('es2019');
 
+import { setDefaultAutoSelectFamilyAttemptTimeout } from 'net';
+// Increase the timeout for the happy eyeballs algorithm to 5000ms to avoid issues on slower networks
+setDefaultAutoSelectFamilyAttemptTimeout(5000);
+
 import { NOTFOUND } from 'dns';
 import mdnsResolver from 'mdns-resolver';
 


### PR DESCRIPTION
On slower networks the default of 250ms can cause problems as all attempts will fail rather than only the ones for interfaces that do not actually work correctly. Increasing this timeout to 5000ms will help to avoid these issues

Change-type: patch

*If this is a regression, consider adding it to #1898!*

# Description

Please include a summary of the change and which issue was fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Type of change

Include at least one commit in your PR that marks the change-type. This can be either specified through a Change-type footer, or by adding the change-type as a prefix to the commit, i.e. minor: Add some new feature. This is so the PR can be automatically versioned and a changelog generated for it by using versionist. Check out [semver](https://semver.org/) for a detailed explanation of the different possible change-type values.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
