### PR TITLE
Log the full error on device state report failure as it is more useful

### DIFF
--- a/src/api-binder/report.ts
+++ b/src/api-binder/report.ts
@@ -186,7 +186,7 @@ function handleRetry(retryInfo: OnFailureInfo) {
 		);
 	} else {
 		eventTracker.track('Device state report failure', {
-			error: retryInfo.error?.message ?? retryInfo.error,
+			error: retryInfo.error,
 		});
 	}
 	log.info(


### PR DESCRIPTION
The message can be an empty string or similarly unhelpful, therefore logging the entire error means that we will have whatever the message may be along with the stack trace and other info that will be helpful even when the message is not

Change-type: patch

*If this is a regression, consider adding it to #1898!*

# Description

Please include a summary of the change and which issue was fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Type of change

Include at least one commit in your PR that marks the change-type. This can be either specified through a Change-type footer, or by adding the change-type as a prefix to the commit, i.e. minor: Add some new feature. This is so the PR can be automatically versioned and a changelog generated for it by using versionist. Check out [semver](https://semver.org/) for a detailed explanation of the different possible change-type values.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
