### PR TITLE
Add revpi-connect-4 to RPi variants

### DIFF
--- a/src/config/backends/config-txt.ts
+++ b/src/config/backends/config-txt.ts
@@ -101,6 +101,7 @@ export class ConfigTxt extends ConfigBackend {
 				'revpi-connect',
 				'revpi-connect-s',
 				'revpi-core-3',
+				'revpi-connect-4',
 			].includes(deviceType) || deviceType.startsWith('raspberry')
 		);
 	}


### PR DESCRIPTION
We need the supervisor to be able to manage config.txt changes for the RevPi Connect 4.
    
Change-type: patch