### PR TITLE
Update lock state apply: patch DockerName & respect lockOverride

### DIFF
--- a/src/device-api/actions.ts
+++ b/src/device-api/actions.ts
@@ -230,16 +230,17 @@ const executeDeviceActionWithLock = async ({
 }) => {
 	try {
 		if (currentService) {
+			const lockOverride = await config.get('lockOverride');
 			// Take lock for current service to be modified / stopped
 			await executeDeviceAction(
 				generateStep('takeLock', {
 					appId,
 					services: [currentService.serviceName],
-					force,
+					force: force || lockOverride,
 				}),
 				// FIXME: deviceState.executeStepAction only accepts force as a separate arg
 				// instead of reading force from the step object, so we have to pass it twice
-				force,
+				force || lockOverride,
 			);
 		}
 

--- a/src/types/basic.ts
+++ b/src/types/basic.ts
@@ -96,7 +96,7 @@ const CONFIG_VAR_NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_:]*$/;
 const shortStringWithRegex = (name: string, regex: RegExp, message: string) =>
 	new t.Type<string, string>(
 		name,
-		(s: unknown): s is string => ShortString.is(s) && VAR_NAME_REGEX.test(s),
+		(s: unknown): s is string => ShortString.is(s) && regex.test(s),
 		(i, c) =>
 			pipe(
 				ShortString.validate(i, c),

--- a/test/integration/lib/update-lock.spec.ts
+++ b/test/integration/lib/update-lock.spec.ts
@@ -15,6 +15,14 @@ import { mkdirp } from '~/lib/fs-utils';
 import { takeGlobalLockRW } from '~/lib/process-lock';
 
 describe('lib/update-lock', () => {
+	before(async () => {
+		await config.initialized();
+	});
+
+	beforeEach(async () => {
+		await config.set({ lockOverride: false });
+	});
+
 	describe('abortIfHUPInProgress', () => {
 		const breadcrumbFiles = [
 			'rollback-health-breadcrumb',
@@ -106,9 +114,6 @@ describe('lib/update-lock', () => {
 			).to.eventually.deep.equal(exists ? supportedLockfiles : []);
 
 		before(async () => {
-			await config.initialized();
-			await config.set({ lockOverride: false });
-
 			// Ensure the directory is available for all tests
 			await fs.mkdir(lockdir(testAppId, testServiceName), {
 				recursive: true,


### PR DESCRIPTION
This PR contains 2 patches:

- Fix some RegEx io-ts types, this was affecting which services were passing the `DockerName` type guard. Services with dashes in their names were not passing before when they should have.
- Respect `lockOverride` when taking locks through state funnel or as an API action