### PR TITLE
Enable redsocks dnsu2t

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -568,7 +568,8 @@ By default, with [balenaOS 2.82.6](https://github.com/balena-os/meta-balena/blob
 			"port": 8123,
 			"login": "username",
 			"password": "password",
-			"noProxy": [ "152.10.30.4", "253.1.1.0/16" ]
+			"noProxy": [ "152.10.30.4", "253.1.1.0/16" ],
+			"dns": "1.1.1.1:53"
 		},
 		"hostname": "mynewhostname",
 		"force": true
@@ -585,7 +586,9 @@ Keep in mind that, even if transparent proxy redirection will take effect immedi
 The `noProxy` setting for the proxy is an optional array of IP addresses/subnets that should not be routed through the
 proxy. Keep in mind that local/reserved subnets are already [excluded by balenaOS automatically](https://github.com/balena-os/meta-balena/blob/master/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config/balena-proxy-config).
 
-If either `proxy` or `hostname` are null or empty values (i.e. `{}` for proxy or an empty string for hostname), they will be cleared to their default values (i.e. not using a proxy, and a hostname equal to the first 7 characters of the device's uuid, respectively).
+As of v16.6.0, the Supervisor supports configuring the `dnsu2t` plugin for redsocks via the `dns` subfield under `proxy`. Only the `remote_ip` and `remote_port` fields are allowed to be modified. The input must be of type `boolean` or `string`. If boolean and `true`, the remote values will be the default, `8.8.8.8:53`. If boolean and false, the configuration will be removed. If string, it should be in the format `ADDRESS:PORT`, with `ADDRESS` and `PORT` both required. You may not configure `dnsu2t` without a redsocks proxy configuration, as `dnsu2t` depends on a working proxy to function.
+
+If any of `proxy`, `dns`, or `hostname` are nullish, falsey, or empty values (i.e. `{}` for proxy, `false` for dns, or an empty string for hostname), they will be cleared to their default settings (i.e. not using a proxy, not using dns, and a hostname equal to the first 7 characters of the device's uuid, respectively).
 
 #### Examples:
 From an app container:
@@ -636,7 +639,8 @@ Response:
 			"port":"8123",
 			"type":"socks5"
 		},
-		"hostname":"27b0fdc"
+		"hostname":"27b0fdc",
+		"dns": "1.1.1.1:53"
 	}
 }
 ```

--- a/src/host-config/index.ts
+++ b/src/host-config/index.ts
@@ -51,9 +51,15 @@ export function parse(
 		const legacyDecoded = LegacyHostConfiguration.decode(conf);
 		if (isRight(legacyDecoded)) {
 			return legacyDecoded.right;
+		} else {
+			const formattedErrorMessage = [
+				'Could not parse host config input to a valid format:',
+			]
+				.concat(Reporter.report(legacyDecoded))
+				.join('\n');
+			throw new Error(formattedErrorMessage);
 		}
 	}
-	throw new Error('Could not parse host config input to a valid format');
 }
 
 function patchProxy(

--- a/src/host-config/proxy.ts
+++ b/src/host-config/proxy.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { isRight } from 'fp-ts/lib/Either';
 import Reporter from 'io-ts-reporters';
 
-import type { RedsocksConfig, HostProxyConfig } from './types';
+import type { RedsocksConfig, HostProxyConfig, DnsInput } from './types';
 import { ProxyConfig } from './types';
 import { pathOnBoot, readFromBoot, writeToBoot } from '../lib/host-utils';
 import { unlinkAll, mkdirp } from '../lib/fs-utils';
@@ -16,6 +16,9 @@ const noProxyPath = path.join(proxyBasePath, 'no_proxy');
 const redsocksConfPath = path.join(proxyBasePath, 'redsocks.conf');
 
 const disallowedProxyFields = ['local_ip', 'local_port'];
+
+const DEFAULT_REMOTE_IP = '8.8.8.8';
+const DEFAULT_REMOTE_PORT = 53;
 
 const isAuthField = (field: string): boolean =>
 	['login', 'password'].includes(field);
@@ -38,18 +41,45 @@ export class RedsocksConf {
 	public static stringify(config: RedsocksConfig): string {
 		const blocks: string[] = [];
 
-		if (config.redsocks && Object.keys(config.redsocks).length > 0) {
-			blocks.push(RedsocksConf.stringifyBlock('base', baseBlock));
-			blocks.push(
-				RedsocksConf.stringifyBlock('redsocks', {
-					...config.redsocks,
-					local_ip: '127.0.0.1',
-					local_port: 12345,
-				}),
-			);
+		// If no redsocks config is provided or dns is the only config, return empty string.
+		// A dns-only config is not valid as it depends on proxy being configured to function.
+		if (
+			!config.redsocks ||
+			!Object.keys(config.redsocks).length ||
+			(Object.keys(config.redsocks).length === 1 &&
+				Object.hasOwn(config.redsocks, 'dns'))
+		) {
+			return '';
 		}
 
-		return blocks.length ? blocks.join('\n') : '';
+		// Add base block
+		blocks.push(RedsocksConf.stringifyBlock('base', baseBlock));
+
+		const { dns, ...redsocks } = config.redsocks;
+		// Add redsocks block
+		blocks.push(
+			RedsocksConf.stringifyBlock('redsocks', {
+				...redsocks,
+				local_ip: '127.0.0.1',
+				local_port: 12345,
+			}),
+		);
+
+		// Add optional dnsu2t block if input dns config is true or a string
+		if (dns != null) {
+			const dnsu2t = dnsToDnsu2t(dns);
+			if (dnsu2t) {
+				blocks.push(
+					RedsocksConf.stringifyBlock('dnsu2t', {
+						...dnsu2t,
+						local_ip: '127.0.0.1',
+						local_port: 53,
+					}),
+				);
+			}
+		}
+
+		return blocks.join('\n');
 	}
 
 	public static parse(rawConf: string): RedsocksConfig {
@@ -135,6 +165,25 @@ export class RedsocksConf {
 		}
 
 		return parsedBlock;
+	}
+}
+
+function dnsToDnsu2t(
+	dns: DnsInput,
+): { remote_ip: string; remote_port: number } | null {
+	const dnsu2t = {
+		remote_ip: DEFAULT_REMOTE_IP,
+		remote_port: DEFAULT_REMOTE_PORT,
+	};
+
+	if (typeof dns === 'boolean') {
+		return dns ? dnsu2t : null;
+	} else {
+		// Convert dns string to config object
+		const [ip, port] = dns.split(':');
+		dnsu2t.remote_ip = ip;
+		dnsu2t.remote_port = parseInt(port, 10);
+		return dnsu2t;
 	}
 }
 

--- a/src/host-config/types.ts
+++ b/src/host-config/types.ts
@@ -47,10 +47,12 @@ export type HostProxyConfig = t.TypeOf<typeof HostProxyConfig>;
  * with host-config PATCH and provided to the user with host-config GET.
  */
 export const HostConfiguration = t.type({
-	network: t.partial({
-		proxy: HostProxyConfig,
-		hostname: t.string,
-	}),
+	network: t.exact(
+		t.partial({
+			proxy: t.exact(HostProxyConfig),
+			hostname: t.string,
+		}),
+	),
 });
 export type HostConfiguration = t.TypeOf<typeof HostConfiguration>;
 
@@ -61,9 +63,11 @@ export type HostConfiguration = t.TypeOf<typeof HostConfiguration>;
  * valid but has the correct shape.
  */
 export const LegacyHostConfiguration = t.type({
-	network: t.partial({
-		proxy: t.record(t.string, t.any),
-		hostname: t.string,
-	}),
+	network: t.exact(
+		t.partial({
+			proxy: t.record(t.string, t.any),
+			hostname: t.string,
+		}),
+	),
 });
 export type LegacyHostConfiguration = t.TypeOf<typeof LegacyHostConfiguration>;

--- a/src/host-config/types.ts
+++ b/src/host-config/types.ts
@@ -82,7 +82,14 @@ export type HostConfiguration = t.TypeOf<typeof HostConfiguration>;
 export const LegacyHostConfiguration = t.type({
 	network: t.exact(
 		t.partial({
-			proxy: t.record(t.string, t.any),
+			proxy: t.intersection([
+				t.record(t.string, t.any),
+				// Dns was added after the initial API endpoint was introduced,
+				// so we can be more strict with its type.
+				t.partial({
+					dns: DnsInput,
+				}),
+			]),
 			hostname: t.string,
 		}),
 	),

--- a/src/host-config/types.ts
+++ b/src/host-config/types.ts
@@ -1,5 +1,15 @@
 import * as t from 'io-ts';
-import { NumericIdentifier } from '../types';
+import { NumericIdentifier, shortStringWithRegex } from '../types';
+
+const AddressString = shortStringWithRegex(
+	'AddressString',
+	/^.+:[0-9]+$/,
+	"must be a string in the format 'ADDRESS:PORT'",
+);
+type AddressString = t.TypeOf<typeof AddressString>;
+
+export const DnsInput = t.union([AddressString, t.boolean]);
+export type DnsInput = t.TypeOf<typeof DnsInput>;
 
 export const ProxyConfig = t.intersection([
 	t.type({
@@ -12,10 +22,11 @@ export const ProxyConfig = t.intersection([
 		ip: t.string,
 		port: NumericIdentifier,
 	}),
-	// login & password are optional fields
+	// login, password, and dns are optional fields
 	t.partial({
 		login: t.string,
 		password: t.string,
+		dns: DnsInput,
 	}),
 ]);
 export type ProxyConfig = t.TypeOf<typeof ProxyConfig>;

--- a/src/host-config/types.ts
+++ b/src/host-config/types.ts
@@ -31,6 +31,12 @@ export const ProxyConfig = t.intersection([
 ]);
 export type ProxyConfig = t.TypeOf<typeof ProxyConfig>;
 
+export const DnsConfig = t.type({
+	remote_ip: t.string,
+	remote_port: NumericIdentifier,
+});
+export type DnsConfig = t.TypeOf<typeof DnsConfig>;
+
 /**
  * The internal object representation of redsocks.conf, obtained
  * from RedsocksConf.parse

--- a/src/types/basic.ts
+++ b/src/types/basic.ts
@@ -93,7 +93,11 @@ const VAR_NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
  */
 const CONFIG_VAR_NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_:]*$/;
 
-const shortStringWithRegex = (name: string, regex: RegExp, message: string) =>
+export const shortStringWithRegex = (
+	name: string,
+	regex: RegExp,
+	message: string,
+) =>
 	new t.Type<string, string>(
 		name,
 		(s: unknown): s is string => ShortString.is(s) && regex.test(s),

--- a/test/data/mnt/boot/system-proxy/redsocks.conf
+++ b/test/data/mnt/boot/system-proxy/redsocks.conf
@@ -15,3 +15,10 @@ redsocks {
 	local_ip = 127.0.0.1;
 	local_port = 12345;
 }
+
+dnsu2t {
+	remote_ip = 1.2.3.4;
+	remote_port = 54;
+	local_ip = 127.0.0.1;
+	local_port = 53;
+}

--- a/test/unit/host-config.spec.ts
+++ b/test/unit/host-config.spec.ts
@@ -259,29 +259,29 @@ describe('RedsocksConf', () => {
 	describe('parse', () => {
 		it('parses config string into RedsocksConfig', () => {
 			const redsocksConfStr = stripIndent`
-                base {
-                    log_debug = off;
-                    log_info = on;
-                    log = stderr;
-                    daemon = off;
-                    redirector = iptables;
-                }
+				base {
+					log_debug = off;
+					log_info = on;
+					log = stderr;
+					daemon = off;
+					redirector = iptables;
+				}
 
-                redsocks {
-                    local_ip = 127.0.0.1;
-                    local_port = 12345;
-                    type = socks5;
-                    ip = example.org;
-                    port = 1080;
-                    login = "foo";
-                    password = "bar";
-                }
+				redsocks {
+					local_ip = 127.0.0.1;
+					local_port = 12345;
+					type = socks5;
+					ip = example.org;
+					port = 1080;
+					login = "foo";
+					password = "bar";
+				}
 
 				dnstc {
 					test = test;
 				}
 
-            `;
+			`;
 			const conf = RedsocksConf.parse(redsocksConfStr);
 			expect(conf).to.deep.equal({
 				redsocks: {
@@ -296,26 +296,26 @@ describe('RedsocksConf', () => {
 
 		it("parses `redsocks {...}` config block no matter what position it's in or how many newlines surround it", () => {
 			const redsocksConfStr = stripIndent`
-				dnsu2t {
+				dnstc {
 					test = test;
 				}
-                redsocks {
-                    local_ip = 127.0.0.1;
-                    local_port = 12345;
-                    type = http-connect;
-                    ip = {test2}.balenadev.io;
-                    port = 1082;
-                    login = "us}{er";
-                    password = "p{}a}}s{{s";
-                }
+				redsocks {
+					local_ip = 127.0.0.1;
+					local_port = 12345;
+					type = http-connect;
+					ip = {test2}.balenadev.io;
+					port = 1082;
+					login = "us}{er";
+					password = "p{}a}}s{{s";
+				}
 				base {
 					log_debug = off;
-                    log_info = on;
-                    log = stderr;
-                    daemon = off;
-                    redirector = iptables;
+					log_info = on;
+					log = stderr;
+					daemon = off;
+					redirector = iptables;
 				}
-            `;
+			`;
 			const conf = RedsocksConf.parse(redsocksConfStr);
 			expect(conf).to.deep.equal({
 				redsocks: {
@@ -406,17 +406,17 @@ describe('RedsocksConf', () => {
 
 		it('parses to empty redsocks config with warnings while any values are invalid', () => {
 			const redsocksConfStr = stripIndent`
-                redsocks {
-                    local_ip = 123;
-                    local_port = foo;
-                    type = socks6;
-                    ip = 456;
-                    port = bar;
-                    login = user;
-                    password = pass;
+				redsocks {
+					local_ip = 123;
+					local_port = foo;
+					type = socks6;
+					ip = 456;
+					port = bar;
+					login = user;
+					password = pass;
 					invalid_field = invalid_value;
-                }
-            `;
+				}
+			`;
 			(log.warn as SinonStub).resetHistory();
 			const conf = RedsocksConf.parse(redsocksConfStr);
 			expect((log.warn as SinonStub).lastCall.args[0]).to.equal(
@@ -436,24 +436,24 @@ describe('RedsocksConf', () => {
 		it('parses to empty config with warnings while some key-value pairs are malformed', () => {
 			// Malformed key-value pairs are pairs that are missing a key, value, or "="
 			const redsocksConfStr = stripIndent`
-                base {
-                    log_debug off;
-                    log_info = on
-                    = stderr;
-                    daemon = ;
-                    redirector = iptables;
-                }
+				base {
+					log_debug off;
+					log_info = on
+					= stderr;
+					daemon = ;
+					redirector = iptables;
+				}
 
-                redsocks {
-                    local_ip 127.0.0.1;
-                    local_port = 12345
-                    = socks5;
-                    ip = ;
-                    = 1080;
-                    login =;
-                    password = "bar";
-                }
-            `;
+				redsocks {
+					local_ip 127.0.0.1;
+					local_port = 12345
+					= socks5;
+					ip = ;
+					= 1080;
+					login =;
+					password = "bar";
+				}
+			`;
 			(log.warn as SinonStub).resetHistory();
 			const conf = RedsocksConf.parse(redsocksConfStr);
 			expect(
@@ -480,12 +480,12 @@ describe('RedsocksConf', () => {
 
 		it('parses to empty config with warnings when a block is empty', () => {
 			const redsocksConfStr = stripIndent`
-                base {
-                }
+				base {
+				}
 
-                redsocks {
-                }
-            `;
+				redsocks {
+				}
+			`;
 			(log.warn as SinonStub).resetHistory();
 			const conf = RedsocksConf.parse(redsocksConfStr);
 			expect(
@@ -504,6 +504,199 @@ describe('RedsocksConf', () => {
 			]);
 			(log.warn as SinonStub).resetHistory();
 			expect(conf).to.deep.equal({});
+		});
+
+		it('parses dnsu2t to dns field in redsocks config', () => {
+			const redsocksConfStr = stripIndent`
+				base {
+					log_debug = off;
+					log_info = on;
+					log = stderr;
+					daemon = off;
+					redirector = iptables;
+				}
+
+				redsocks {
+					local_ip = 127.0.0.1;
+					local_port = 12345;
+					type = socks5;
+					ip = example.org;
+					port = 1080;
+					login = "foo";
+					password = "bar";
+				}
+
+				dnsu2t {
+					remote_ip = 1.1.1.1;
+					remote_port = 54;
+					local_ip = 127.0.0.1;
+					local_port = 53;
+				}
+			`;
+			const conf = RedsocksConf.parse(redsocksConfStr);
+			expect(conf).to.deep.equal({
+				redsocks: {
+					type: 'socks5',
+					ip: 'example.org',
+					port: 1080,
+					login: 'foo',
+					password: 'bar',
+					dns: '1.1.1.1:54',
+				},
+			});
+		});
+
+		it('parses dnsu2t no matter its position', () => {
+			const redsocksConfStr = stripIndent`
+				base {
+					log_debug = off;
+					log_info = on;
+					log = stderr;
+					daemon = off;
+					redirector = iptables;
+				}
+
+				dnsu2t {
+					remote_ip = 1.1.1.1;
+					remote_port = 54;
+					local_ip = 127.0.0.1;
+					local_port = 53;
+				}
+				redsocks {
+					local_ip = 127.0.0.1;
+					local_port = 12345;
+					type = socks5;
+					ip = example.org;
+					port = 1080;
+					login = "foo";
+					password = "bar";
+				}
+			`;
+			const conf = RedsocksConf.parse(redsocksConfStr);
+			expect(conf).to.deep.equal({
+				redsocks: {
+					type: 'socks5',
+					ip: 'example.org',
+					port: 1080,
+					login: 'foo',
+					password: 'bar',
+					dns: '1.1.1.1:54',
+				},
+			});
+		});
+
+		it('does not parse dnsu2t to dns field if dnsu2t is partial or invalid', () => {
+			const redsocksConfStr = stripIndent`
+				base {
+					log_debug = off;
+					log_info = on;
+					log = stderr;
+					daemon = off;
+					redirector = iptables;
+				}
+
+				redsocks {
+					local_ip = 127.0.0.1;
+					local_port = 12345;
+					type = socks5;
+					ip = example.org;
+					port = 1080;
+					login = "foo";
+					password = "bar";
+				}
+
+				dnsu2t {
+					test = true;
+				}
+			`;
+			const conf = RedsocksConf.parse(redsocksConfStr);
+			expect(conf).to.deep.equal({
+				redsocks: {
+					type: 'socks5',
+					ip: 'example.org',
+					port: 1080,
+					login: 'foo',
+					password: 'bar',
+				},
+			});
+
+			const redsocksConfStr2 = stripIndent`
+				base {
+					log_debug = off;
+					log_info = on;
+					log = stderr;
+					daemon = off;
+					redirector = iptables;
+				}
+
+				redsocks {
+					local_ip = 127.0.0.1;
+					local_port = 12345;
+					type = socks5;
+					ip = example.org;
+					port = 1080;
+					login = "foo";
+					password = "bar";
+				}
+
+				dnsu2t {
+					remote_port = 53;
+				}
+			`;
+			const conf2 = RedsocksConf.parse(redsocksConfStr2);
+			expect(conf2).to.deep.equal({
+				redsocks: {
+					type: 'socks5',
+					ip: 'example.org',
+					port: 1080,
+					login: 'foo',
+					password: 'bar',
+				},
+			});
+		});
+
+		it('does not parse dnsu2t to dns field if missing or invalid redsocks config', () => {
+			const redsocksConfStr = stripIndent`
+				base {
+					log_debug = off;
+					log_info = on;
+					log = stderr;
+					daemon = off;
+					redirector = iptables;
+				}
+
+				dnsu2t {
+					remote_ip = 1.1.1.1;
+					remote_port = 54;
+					local_ip = 127.0.0.1;
+					local_port = 53;
+				}
+			`;
+			const conf = RedsocksConf.parse(redsocksConfStr);
+			expect(conf).to.deep.equal({});
+
+			const redsocksConfStr2 = stripIndent`
+				base {
+					log_debug = off;
+					log_info = on;
+					log = stderr;
+					daemon = off;
+					redirector = iptables;
+				}
+
+				redsocks {
+					type = socks5;
+				}
+
+				dnsu2t {
+					remote_ip = 1.1.1.1;
+					remote_port = 54;
+					local_ip = 127.0.0.1;
+					local_port = 53;
+				}
+			`;
+			const conf2 = RedsocksConf.parse(redsocksConfStr2);
+			expect(conf2).to.deep.equal({});
 		});
 	});
 });


### PR DESCRIPTION
## Release Notes
Support dnsu2t redsocks proxy config
    
Users may specify dnsu2t config by including a `dns` field
in their PATCH body:
```
{
  network: {
    proxy: {
      dns: '1.1.1.1:53'
    },
    hostname: 'balena'
  }
}
```

If `dns` is a string, IP and PORT are optional but should be in
the format [IP][:PORT] if present. For any fields that are empty,
a default IP and PORT (`8.8.8.8:53`) will be configured.

`dns` may also be a boolean. If true, defaults of `8.8.8.8:53` will be configured.
If false, the dns configuration will be removed.

If `proxy` is patched to empty, `dns` will be removed regardless of its
current or input configs, as `dns` depends on an active redsocks
proxy to function.

Change-type: minor
Signed-off-by: Christina Ying Wang <christina@balena.io>