### PR TITLE
Uninstall containers using force remove

### DIFF
--- a/src/compose/composition-steps.ts
+++ b/src/compose/composition-steps.ts
@@ -14,9 +14,6 @@ import type { DeviceLegacyReport } from '../types/state';
 interface CompositionStepArgs {
 	stop: {
 		current: Service;
-		options?: {
-			wait?: boolean;
-		};
 	};
 	kill: {
 		current: Service;
@@ -119,10 +116,7 @@ export function getExecutors(app: { callbacks: CompositionCallbacks }) {
 		stop: async (step) => {
 			// Should always be preceded by a takeLock step,
 			// so the call is executed assuming that the lock is taken.
-			await serviceManager.kill(step.current, {
-				removeContainer: false,
-				wait: step.options?.wait || false,
-			});
+			await serviceManager.stop(step.current);
 		},
 		kill: async (step) => {
 			// Should always be preceded by a takeLock step,

--- a/src/lib/log-types.ts
+++ b/src/lib/log-types.ts
@@ -19,6 +19,10 @@ export const stopRemoveServiceNoop: LogType = {
 	eventName: 'Service already stopped and container removed',
 	humanName: 'Service is already stopped and the container removed',
 };
+export const stopService404Error: LogType = {
+	eventName: 'Service stop error',
+	humanName: 'Service container not found',
+};
 export const stopServiceError: LogType = {
 	eventName: 'Service stop error',
 	humanName: 'Failed to kill service',


### PR DESCRIPTION
When uninstalling a container for a restart from the API on when moving between releases, this prefers to force remove the container rather than stop then remove. This has the same effect in the end, but force remove is an atomic call, meaning if the supervisor is killed between the stop and remove, the engine will proceed with the operation and the supervisor will know to recover from the target state after the restart.

Change-type: patch
Relates-to: #2257 