### PR TITLE
Fix engine deadlock on network+service change

### DIFF
--- a/test/integration/.mocharc.js
+++ b/test/integration/.mocharc.js
@@ -10,5 +10,5 @@ module.exports = {
 		'test/lib/chai.ts',
 		'test/lib/mocha-hooks.ts',
 	],
-	timeout: '30000',
+	timeout: '60000',
 };


### PR DESCRIPTION
This fixes a regression on the supervisor state engine computation (added on v16.2.0) when
the target state removes a network at the same time that a service
referencing that network is changed. Example going from

```
# Old release
services:
   one:
      image: alpine: 3.18
      networks: ['balena']

networks:
   balena:
```

to

```
# New release
services:
   one:
      image: alpine: latest
```

Would never reach the target state as killing the service in order to
remove the network is prioritized, but one of the invariants in the target state calculation is
to not kill any services until all images have been downloaded. These
two instructions were in contradiction leading to a deadlock.

The fix involves only adding removal steps for services depending on a
changing network or volume if the service container is not being removed
already.

Change-type: patch