### PR TITLE
Cleanup images after state-engine tests

### DIFF
--- a/test/integration/state-engine.spec.ts
+++ b/test/integration/state-engine.spec.ts
@@ -85,6 +85,7 @@ describe('state engine', () => {
 			config: {},
 			apps: {},
 		});
+		await docker.pruneImages({ filters: { dangling: { false: true } } });
 	});
 
 	it('installs an app with two services', async () => {


### PR DESCRIPTION
Tests on GitHub started failing recently because of leftover images from the state engine test suite. This fixes that issue to allow tests to pass.

Change-type: patch