### PR TITLE
Do not write `noProxy` to redsocks.conf

### DIFF
--- a/src/host-config/index.ts
+++ b/src/host-config/index.ts
@@ -94,7 +94,7 @@ export async function patch(
 	}
 
 	if (conf.network.proxy != null) {
-		const targetConf = conf.network.proxy;
+		const { noProxy, ...targetConf } = conf.network.proxy;
 		// It's possible for appIds to be an empty array, but patch shouldn't fail
 		// as it's not dependent on there being any running user applications.
 		return updateLock.lock(appIds, { force }, async () => {
@@ -114,7 +114,7 @@ export async function patch(
 					redsocks: targetConf,
 				},
 			);
-			await setProxy(patchedConf, targetConf.noProxy);
+			await setProxy(patchedConf, noProxy);
 		});
 	}
 }

--- a/src/host-config/proxy.ts
+++ b/src/host-config/proxy.ts
@@ -157,7 +157,7 @@ export async function readProxy(): Promise<HostProxyConfig | undefined> {
 	// Build proxy object
 	const proxy = {
 		...redsocksConf.redsocks,
-		...(noProxy.length && { noProxy }),
+		...(noProxy.length > 0 && { noProxy }),
 	};
 
 	// Assumes mandatory proxy config fields (type, ip, port) are present,


### PR DESCRIPTION
This fixes a regression introduced by the refactor in #2329 where `noProxy` was being included in the data added to redsocks.conf.

Change-type: patch