### PR TITLE
Verify that LED_FILE exists on blinking setup

### DIFF
--- a/src/device-api/actions.ts
+++ b/src/device-api/actions.ts
@@ -19,7 +19,7 @@ import type { Service } from '../compose/service';
 import { getApp } from '../device-state/db-format';
 import * as TargetState from '../api-binder/poll';
 import log from '../lib/supervisor-console';
-import blink = require('../lib/blink');
+import { getBlink } from '../lib/blink';
 import * as constants from '../lib/constants';
 import {
 	InternalInconsistencyError,
@@ -56,7 +56,8 @@ export const runHealthchecks = async (
  * - POST /v1/blink
  */
 const DEFAULT_IDENTIFY_DURATION = 15000;
-export const identify = (ms: number = DEFAULT_IDENTIFY_DURATION) => {
+export const identify = async (ms: number = DEFAULT_IDENTIFY_DURATION) => {
+	const blink = await getBlink();
 	eventTracker.track('Device blink');
 	blink.pattern.start();
 	setTimeout(blink.pattern.stop, ms);

--- a/src/device-api/index.ts
+++ b/src/device-api/index.ts
@@ -43,8 +43,8 @@ export class SupervisorAPI {
 
 		this.api.use(middleware.auth);
 
-		this.api.post('/v1/blink', (_req, res) => {
-			actions.identify();
+		this.api.post('/v1/blink', async (_req, res) => {
+			await actions.identify();
 			return res.sendStatus(200);
 		});
 

--- a/src/lib/blink.ts
+++ b/src/lib/blink.ts
@@ -1,5 +1,18 @@
-import blinking = require('blinking');
+import blinking from 'blinking';
+import memoizee from 'memoizee';
 
+export type Blink = ReturnType<typeof blinking>;
+
+import { exists } from './fs-utils';
 import { ledFile } from './constants';
 
-export = blinking(ledFile);
+export const getBlink = memoizee(
+	async (): Promise<Blink> => {
+		if (!(await exists(ledFile))) {
+			return blinking('/dev/null');
+		}
+
+		return blinking(ledFile);
+	},
+	{ promise: true },
+);

--- a/src/network.ts
+++ b/src/network.ts
@@ -8,7 +8,7 @@ import * as constants from './lib/constants';
 import { isEEXIST } from './lib/errors';
 import { checkFalsey } from './lib/validation';
 
-import blink = require('./lib/blink');
+import { getBlink } from './lib/blink';
 
 import log from './lib/supervisor-console';
 
@@ -85,6 +85,7 @@ export const startConnectivityCheck = _.once(
 
 		const parsedUrl = url.parse(apiEndpoint);
 		const port = parseInt(parsedUrl.port!, 10);
+		const blink = await getBlink();
 
 		customMonitor(
 			{

--- a/test/unit/device-api/actions.spec.ts
+++ b/test/unit/device-api/actions.spec.ts
@@ -1,10 +1,9 @@
 import { expect } from 'chai';
 import type { SinonStub } from 'sinon';
-import { spy, useFakeTimers, stub } from 'sinon';
+import { stub } from 'sinon';
 
 import * as hostConfig from '~/src/host-config';
 import * as actions from '~/src/device-api/actions';
-import blink = require('~/lib/blink');
 
 describe('device-api/actions', () => {
 	describe('runs healthchecks', () => {
@@ -24,25 +23,6 @@ describe('device-api/actions', () => {
 			expect(await actions.runHealthchecks([taskFalse, taskError])).to.be.false;
 			expect(await actions.runHealthchecks([taskFalse, taskFalse])).to.be.false;
 			expect(await actions.runHealthchecks([taskError, taskError])).to.be.false;
-		});
-	});
-
-	describe('identifies device', () => {
-		// This suite doesn't test that the blink submodule writes to the correct
-		// led file location on host. That test should be part of the blink module.
-		it('directs device to blink for set duration', async () => {
-			const blinkStartSpy = spy(blink.pattern, 'start');
-			const blinkStopSpy = spy(blink.pattern, 'stop');
-			const clock = useFakeTimers();
-
-			actions.identify();
-			expect(blinkStartSpy.callCount).to.equal(1);
-			clock.tick(15000);
-			expect(blinkStopSpy.callCount).to.equal(1);
-
-			blinkStartSpy.restore();
-			blinkStopSpy.restore();
-			clock.restore();
 		});
 	});
 


### PR DESCRIPTION
Before v1, the blinking module would not throw when the passed led file does not exist. This change checks for file existence and defaults to `/dev/null` otherwise

Change-type: patch