### PR TITLE
Add kmod to runtime-base

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -95,7 +95,8 @@ RUN apk add --update --no-cache \
 	dbus \
 	dmidecode \
 	sqlite-libs \
-	lsblk
+	lsblk \
+	kmod
 
 # Iptables should be pinned to 1.8.9 (legacy) as balenaOS still uses iptables-legacy
 RUN apk add --update --no-cache \


### PR DESCRIPTION
balenaOS v6 enables zstd module compression by default. Add kmod to runtime-base to support loading of compressed modules.

Change-type: patch

*If this is a regression, consider adding it to #1898!*

# Description

Please include a summary of the change and which issue was fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Type of change

Include at least one commit in your PR that marks the change-type. This can be either specified through a Change-type footer, or by adding the change-type as a prefix to the commit, i.e. minor: Add some new feature. This is so the PR can be automatically versioned and a changelog generated for it by using versionist. Check out [semver](https://semver.org/) for a detailed explanation of the different possible change-type values.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
