### PR TITLE
io.balena.features.bootfs compose label for /mnt/boot access

### DIFF
--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -394,6 +394,8 @@ export async function addFeaturesFromLabels(
 		'io.balena.features.sysfs': () => service.config.volumes.push('/sys:/sys'),
 		'io.balena.features.procfs': () =>
 			service.config.volumes.push('/proc:/proc'),
+		'io.balena.features.bootfs': () =>
+			service.config.volumes.push('/mnt/boot:/mnt/boot'),
 		'io.balena.features.gpu': () =>
 			// TODO once the compose-spec has an implementation we
 			// should probably follow that, for now we copy the


### PR DESCRIPTION
Change-type: minor

# Description

Provides the possibility of bind mounting the host balenaOS /mnt/boot into a container via a new `io.balena.features.bootfs` compose label

Fixes #2371