### PR TITLE
Downgrade to Node 18

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,8 +1,8 @@
 ARG ARCH=%%BALENA_ARCH%%
 ARG FATRW_VERSION=0.2.21
-ARG NODE="nodejs~=20"
-ARG NPM="npm~=10"
-ARG ALPINE_VERSION="3.19"
+ARG NODE="nodejs~=18"
+ARG NPM="npm~=9"
+ARG ALPINE_VERSION="3.18"
 
 ###################################################
 # Build the supervisor dependencies
@@ -43,6 +43,9 @@ RUN FATRW_ARCHIVE="fatrw-$(/rust-arch.sh).tar.gz" && \
 
 # Just install dev dependencies first
 RUN npm ci --build-from-source=sqlite3 --sqlite=/usr/lib
+
+# Echo node version
+RUN node --version
 
 ###################################################################
 # Journal access.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "sqlite3": "^5.1.6"
   },
   "engines": {
-    "node": ">=20 <21",
+    "node": ">=18 <20",
     "npm": ">=10"
   },
   "devDependencies": {


### PR DESCRIPTION
Due to linked issue, Supervisor livepush does not work for armv6, armv7, or armv8 for Node 20, but does work for Node 18. This is a temporary downgrade until the linked issue is patched.

See: https://github.com/nodejs/docker-node/issues/1946
Change-type: patch