### PR TITLE
Use bookworm image to source journalctl binaries

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -51,7 +51,7 @@ RUN npm ci --build-from-source=sqlite3 --sqlite=/usr/lib
 # musl. We hack around this by copying the binary and its library
 # dependencies to the final image
 ###################################################################
-FROM debian:bullseye-slim AS journal
+FROM debian:bookworm-slim AS journal
 
 RUN apt-get update && apt-get install -y --no-install-recommends systemd
 


### PR DESCRIPTION
Debian no longer publishes linux/arm/v5 images for bullseye, breaking support for raspberry pi zero.

This change might not solve the issue indefinitely as we don't know how long debian will continue publishing armv5 images.

Change-type: patch