### PR TITLE
Add support for `io.balena.update.requires-reboot` label

### DIFF
--- a/src/api-binder/index.ts
+++ b/src/api-binder/index.ts
@@ -5,7 +5,6 @@ import _ from 'lodash';
 import type { PinejsClientRequest } from 'pinejs-client-request';
 
 import * as config from '../config';
-import * as deviceConfig from '../device-config';
 import * as eventTracker from '../event-tracker';
 import { loadBackupFromMigration } from '../lib/migration';
 
@@ -332,10 +331,10 @@ async function reportInitialEnv(
 		);
 	}
 
-	const defaultConfig = deviceConfig.getDefaults();
+	const defaultConfig = deviceState.getDefaultConfig();
 
-	const currentConfig = await deviceConfig.getCurrent();
-	const targetConfig = deviceConfig.formatConfigKeys(targetConfigUnformatted);
+	const currentConfig = await deviceState.getCurrentConfig();
+	const targetConfig = deviceState.formatConfigKeys(targetConfigUnformatted);
 
 	if (!currentConfig) {
 		throw new InternalInconsistencyError(

--- a/src/compose/composition-steps.ts
+++ b/src/compose/composition-steps.ts
@@ -6,6 +6,7 @@ import * as networkManager from './network-manager';
 import * as volumeManager from './volume-manager';
 import * as commitStore from './commit';
 import { Lockable, cleanLocksForApp } from '../lib/update-lock';
+import { setRebootBreadcrumb } from '../lib/reboot';
 import type { DeviceLegacyReport } from '../types/state';
 import type { CompositionStepAction, CompositionStepT } from './types';
 import type { Lock } from '../lib/update-lock';
@@ -156,6 +157,9 @@ export function getExecutors(app: { callbacks: CompositionCallbacks }) {
 			}
 			// Clean up any remaining locks
 			await cleanLocksForApp(step.appId);
+		},
+		requireReboot: async (step) => {
+			await setRebootBreadcrumb({ serviceName: step.serviceName });
 		},
 	};
 

--- a/src/compose/service-manager.ts
+++ b/src/compose/service-manager.ts
@@ -19,7 +19,7 @@ import {
 	isStatusError,
 } from '../lib/errors';
 import * as LogTypes from '../lib/log-types';
-import { checkInt, isValidDeviceName } from '../lib/validation';
+import { checkInt, isValidDeviceName, checkTruthy } from '../lib/validation';
 import { Service } from './service';
 import type { ServiceStatus } from './types';
 import { serviceNetworksToDockerNetworks } from './utils';
@@ -27,6 +27,7 @@ import { serviceNetworksToDockerNetworks } from './utils';
 import log from '../lib/supervisor-console';
 import logMonitor from '../logging/monitor';
 import { setTimeout } from 'timers/promises';
+import { getBootTime } from '../lib/fs-utils';
 
 interface ServiceManagerEvents {
 	change: void;
@@ -233,7 +234,7 @@ export async function remove(service: Service) {
 	}
 }
 
-async function create(service: Service) {
+async function create(service: Service): Promise<Service> {
 	const mockContainerId = config.newUniqueKey();
 	try {
 		const existing = await get(service);
@@ -242,7 +243,7 @@ async function create(service: Service) {
 				`No containerId provided for service ${service.serviceName} in ServiceManager.updateMetadata. Service: ${service}`,
 			);
 		}
-		return docker.getContainer(existing.containerId);
+		return existing;
 	} catch (e: unknown) {
 		if (!isNotFoundError(e)) {
 			logger.logSystemEvent(LogTypes.installServiceError, {
@@ -287,7 +288,9 @@ async function create(service: Service) {
 		reportNewStatus(mockContainerId, service, 'Installing');
 
 		const container = await docker.createContainer(conf);
-		service.containerId = container.id;
+		const inspectInfo = await container.inspect();
+
+		service = Service.fromDockerContainer(inspectInfo);
 
 		await Promise.all(
 			_.map((nets || {}).EndpointsConfig, (endpointConfig, name) =>
@@ -299,7 +302,7 @@ async function create(service: Service) {
 		);
 
 		logger.logSystemEvent(LogTypes.installServiceSuccess, { service });
-		return container;
+		return service;
 	} finally {
 		reportChange(mockContainerId);
 	}
@@ -310,13 +313,25 @@ export async function start(service: Service) {
 	let containerId: string | null = null;
 
 	try {
-		const container = await create(service);
+		const svc = await create(service);
+		const container = docker.getContainer(svc.containerId!);
+
+		const requiresReboot =
+			checkTruthy(
+				service.config.labels?.['io.balena.update.requires-reboot'],
+			) &&
+			svc.createdAt != null &&
+			svc.createdAt > getBootTime();
+
+		if (requiresReboot) {
+			log.warn(`Skipping start of service ${svc.serviceName} until reboot`);
+		}
 
 		// Exit here if the target state of the service
-		// is set to running: false
+		// is set to running: false or we are waiting for a reboot
 		// QUESTION: should we split the service steps into
 		// 'install' and 'start' instead of doing this?
-		if (service.config.running === false) {
+		if (service.config.running === false || requiresReboot) {
 			return container;
 		}
 

--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -128,7 +128,6 @@ class ServiceImpl implements Service {
 		service.releaseId = parseInt(appConfig.releaseId, 10);
 		service.serviceId = parseInt(appConfig.serviceId, 10);
 		service.imageName = appConfig.image;
-		service.createdAt = appConfig.createdAt;
 		service.commit = appConfig.commit;
 		service.appUuid = appConfig.appUuid;
 

--- a/src/compose/types/app.ts
+++ b/src/compose/types/app.ts
@@ -12,6 +12,8 @@ export interface UpdateState {
 	hasLeftoverLocks: boolean;
 	lock: Lock | null;
 	force: boolean;
+	rebootBreadcrumbSet: boolean;
+	bootTime: Date;
 }
 
 export interface App {

--- a/src/compose/types/composition-step.ts
+++ b/src/compose/types/composition-step.ts
@@ -76,6 +76,7 @@ export interface CompositionStepArgs {
 		appId: string | number;
 		lock: Lock | null;
 	};
+	requireReboot: { serviceName: string };
 }
 
 export type CompositionStepAction = keyof CompositionStepArgs;

--- a/src/device-api/v2.ts
+++ b/src/device-api/v2.ts
@@ -11,7 +11,6 @@ import { Volume } from '../compose/volume';
 import * as commitStore from '../compose/commit';
 import * as config from '../config';
 import * as db from '../db';
-import * as deviceConfig from '../device-config';
 import * as logger from '../logging';
 import * as images from '../compose/images';
 import * as volumeManager from '../compose/volume-manager';
@@ -512,7 +511,7 @@ router.get('/v2/device/tags', async (_req, res) => {
 });
 
 router.get('/v2/device/vpn', async (_req, res) => {
-	const conf = await deviceConfig.getCurrent();
+	const conf = await deviceState.getCurrentConfig();
 	// Build VPNInfo
 	const info = {
 		enabled: conf.SUPERVISOR_VPN_CONTROL === 'true',

--- a/src/device-state/device-config.ts
+++ b/src/device-state/device-config.ts
@@ -2,21 +2,22 @@ import _ from 'lodash';
 import { inspect } from 'util';
 import { promises as fs } from 'fs';
 
-import * as config from './config';
-import * as db from './db';
-import * as logger from './logging';
-import * as dbus from './lib/dbus';
-import type { EnvVarObject } from './types';
-import { UnitNotLoadedError } from './lib/errors';
-import { checkInt, checkTruthy } from './lib/validation';
-import log from './lib/supervisor-console';
-import * as configUtils from './config/utils';
-import type { SchemaTypeKey } from './config/schema-type';
-import { matchesAnyBootConfig } from './config/backends';
-import type { ConfigBackend } from './config/backends/backend';
-import { Odmdata } from './config/backends/odmdata';
-import * as fsUtils from './lib/fs-utils';
-import { pathOnRoot } from './lib/host-utils';
+import * as config from '../config';
+import * as db from '../db';
+import * as logger from '../logging';
+import * as dbus from '../lib/dbus';
+import type { EnvVarObject } from '../types';
+import { UnitNotLoadedError } from '../lib/errors';
+import { checkInt, checkTruthy } from '../lib/validation';
+import log from '../lib/supervisor-console';
+import * as fsUtils from '../lib/fs-utils';
+import { pathOnRoot } from '../lib/host-utils';
+
+import * as configUtils from '../config/utils';
+import type { SchemaTypeKey } from '../config/schema-type';
+import { matchesAnyBootConfig } from '../config/backends';
+import type { ConfigBackend } from '../config/backends/backend';
+import { Odmdata } from '../config/backends/odmdata';
 
 const vpnServiceName = 'openvpn';
 
@@ -210,7 +211,7 @@ const configKeys: Dictionary<ConfigOption> = {
 	},
 };
 
-export const validKeys = [
+const validKeys = [
 	'SUPERVISOR_VPN_CONTROL',
 	'OVERRIDE_LOCK',
 	..._.map(configKeys, 'envVarName'),

--- a/src/device-state/index.ts
+++ b/src/device-state/index.ts
@@ -19,6 +19,7 @@ import * as updateLock from '../lib/update-lock';
 import { getGlobalApiKey } from '../lib/api-keys';
 import * as sysInfo from '../lib/system-info';
 import { log } from '../lib/supervisor-console';
+import { isRebootRequired } from '../lib/reboot';
 import { loadTargetFromFile } from './preload';
 import * as applicationManager from '../compose/application-manager';
 import * as commitStore from '../compose/commit';
@@ -518,7 +519,7 @@ export async function executeStepAction(
 	}
 }
 
-export async function applyStep(
+async function applyStep(
 	step: DeviceStateStep<PossibleStepTargets>,
 	{
 		force,
@@ -615,11 +616,12 @@ export const applyTarget = async ({
 			({ action }) => action === 'noop',
 		);
 
-		let backoff: boolean;
+		const rebootRequired = await isRebootRequired();
+
+		let backoff = false;
 		let steps: Array<DeviceStateStep<PossibleStepTargets>>;
 
 		if (!noConfigSteps) {
-			backoff = false;
 			steps = deviceConfigSteps;
 		} else {
 			const appSteps = await applicationManager.getRequiredSteps(
@@ -644,6 +646,21 @@ export const applyTarget = async ({
 				backoff = false;
 				steps = appSteps;
 			}
+		}
+
+		// Check if there is either no steps, or they are all
+		// noops, and we need to reboot. We want to do this
+		// because in a preloaded setting with no internet
+		// connection, the device will try to start containers
+		// before any boot config has been applied, which can
+		// cause problems
+		// For application manager, the reboot breadcrumb should
+		// be set after all downloads are ready and target containers
+		// have been installed
+		if (_.every(steps, ({ action }) => action === 'noop') && rebootRequired) {
+			steps.push({
+				action: 'reboot',
+			});
 		}
 
 		if (_.isEmpty(steps)) {

--- a/src/device-state/index.ts
+++ b/src/device-state/index.ts
@@ -657,7 +657,7 @@ export const applyTarget = async ({
 		// For application manager, the reboot breadcrumb should
 		// be set after all downloads are ready and target containers
 		// have been installed
-		if (_.every(steps, ({ action }) => action === 'noop') && rebootRequired) {
+		if (steps.every(({ action }) => action === 'noop') && rebootRequired) {
 			steps.push({
 				action: 'reboot',
 			});

--- a/src/device-state/index.ts
+++ b/src/device-state/index.ts
@@ -9,7 +9,7 @@ import * as config from '../config';
 import * as logger from '../logging';
 
 import * as network from '../network';
-import * as deviceConfig from '../device-config';
+import * as deviceConfig from './device-config';
 
 import * as constants from '../lib/constants';
 import * as dbus from '../lib/dbus';
@@ -25,6 +25,12 @@ import * as commitStore from '../compose/commit';
 import type { InstancedDeviceState } from './target-state';
 import * as TargetState from './target-state';
 export { getTarget, setTarget } from './target-state';
+
+export {
+	formatConfigKeys,
+	getCurrent as getCurrentConfig,
+	getDefaults as getDefaultConfig,
+} from './device-config';
 
 import type { DeviceLegacyState, DeviceState, DeviceReport } from '../types';
 import type {

--- a/src/device-state/preload.ts
+++ b/src/device-state/preload.ts
@@ -6,9 +6,9 @@ import { imageFromService } from '../compose/images';
 import { NumericIdentifier } from '../types';
 import { setTarget } from './target-state';
 import * as config from '../config';
-import * as deviceConfig from '../device-config';
 import * as eventTracker from '../event-tracker';
 import * as imageManager from '../compose/images';
+import * as deviceState from '../device-state';
 
 import {
 	AppsJsonParseError,
@@ -126,8 +126,8 @@ export async function loadTargetFromFile(appsPath: string): Promise<boolean> {
 			await imageManager.save(image);
 		}
 
-		const deviceConf = await deviceConfig.getCurrent();
-		const formattedConf = deviceConfig.formatConfigKeys(preloadState.config);
+		const deviceConf = await deviceState.getCurrentConfig();
+		const formattedConf = deviceState.formatConfigKeys(preloadState.config);
 		const localState = {
 			[uuid]: {
 				name: '',

--- a/src/device-state/target-state.ts
+++ b/src/device-state/target-state.ts
@@ -6,7 +6,7 @@ import * as config from '../config';
 import * as db from '../db';
 
 import * as globalEventBus from '../event-bus';
-import * as deviceConfig from '../device-config';
+import * as deviceConfig from './device-config';
 
 import { TargetStateError } from '../lib/errors';
 import { takeGlobalLockRO, takeGlobalLockRW } from '../lib/process-lock';

--- a/src/lib/fs-utils.ts
+++ b/src/lib/fs-utils.ts
@@ -87,5 +87,4 @@ export const touch = (file: string, time = new Date()) =>
 	);
 
 // Get the system boot time as a Date object
-export const getBootTime = () =>
-	new Date(new Date().getTime() - uptime() * 1000);
+export const getBootTime = () => new Date(Date.now() - uptime() * 1000);

--- a/src/lib/reboot.ts
+++ b/src/lib/reboot.ts
@@ -1,6 +1,7 @@
 import { pathOnRoot } from '../lib/host-utils';
 import * as fsUtils from '../lib/fs-utils';
 import { promises as fs } from 'fs';
+import * as logger from '../logging';
 
 // This indicates the file on the host /tmp directory that
 // marks the need for a reboot. Since reboot is only triggered for now
@@ -11,10 +12,19 @@ const REBOOT_BREADCRUMB = pathOnRoot(
 	'/tmp/balena-supervisor/reboot-after-apply',
 );
 
-export async function setRebootBreadcrumb() {
+export async function setRebootBreadcrumb(source: Dictionary<any> = {}) {
 	// Just create the file. The last step in the target state calculation will check
 	// the file and create a reboot step
 	await fsUtils.touch(REBOOT_BREADCRUMB);
+	logger.logSystemMessage(
+		`Reboot has been scheduled to apply changes: ${JSON.stringify(source)}`,
+		{},
+		'Reboot scheduled',
+	);
+}
+
+export async function isRebootBreadcrumbSet() {
+	return await fsUtils.exists(REBOOT_BREADCRUMB);
 }
 
 export async function isRebootRequired() {

--- a/src/lib/reboot.ts
+++ b/src/lib/reboot.ts
@@ -1,0 +1,30 @@
+import { pathOnRoot } from '../lib/host-utils';
+import * as fsUtils from '../lib/fs-utils';
+import { promises as fs } from 'fs';
+
+// This indicates the file on the host /tmp directory that
+// marks the need for a reboot. Since reboot is only triggered for now
+// by some config changes, we leave this here for now. There is planned
+// functionality to allow image installs to require reboots, at that moment
+// this constant can be moved somewhere else
+const REBOOT_BREADCRUMB = pathOnRoot(
+	'/tmp/balena-supervisor/reboot-after-apply',
+);
+
+export async function setRebootBreadcrumb() {
+	// Just create the file. The last step in the target state calculation will check
+	// the file and create a reboot step
+	await fsUtils.touch(REBOOT_BREADCRUMB);
+}
+
+export async function isRebootRequired() {
+	const hasBreadcrumb = await fsUtils.exists(REBOOT_BREADCRUMB);
+	if (hasBreadcrumb) {
+		const stats = await fs.stat(REBOOT_BREADCRUMB);
+
+		// If the breadcrumb exists and the last modified time is greater than the
+		// boot time, that means we need to reboot
+		return stats.mtime.getTime() > fsUtils.getBootTime().getTime();
+	}
+	return false;
+}

--- a/test/integration/device-config.spec.ts
+++ b/test/integration/device-config.spec.ts
@@ -5,7 +5,7 @@ import type { SinonStub, SinonSpy } from 'sinon';
 import { stub, spy } from 'sinon';
 import { expect } from 'chai';
 
-import * as deviceConfig from '~/src/device-config';
+import * as deviceConfig from '~/src/device-state/device-config';
 import * as fsUtils from '~/lib/fs-utils';
 import * as logger from '~/src/logging';
 import { Extlinux } from '~/src/config/backends/extlinux';

--- a/test/legacy/40-target-state.spec.ts
+++ b/test/legacy/40-target-state.spec.ts
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 import * as TargetState from '~/src/api-binder/poll';
 import Log from '~/lib/supervisor-console';
 import * as request from '~/lib/request';
-import * as deviceConfig from '~/src/device-config';
+import * as deviceConfig from '~/src/device-state/device-config';
 import { UpdatesLockedError } from '~/lib/errors';
 import { setTimeout } from 'timers/promises';
 


### PR DESCRIPTION
This label can be used by user services to indicate that a reboot is required after the install of a service in order to fully apply an update. In particular, this will be used by hostOS updates when we add this feature on the supervisor.

Change-type: minor
Depends-on: #2389

## Release notes

This release adds support for a new docker-compose label: `io.balena.update.requires-reboot`. When the label is present on a service, it tells the supervisor that a system reboot should be performed before starting the service for the first time. 

When a target release is received that contains services with this label, the supervisor will
- pull all target images
- create and start containers for services without the label (in dependency order).
- create containers for services with the label, but skip start
- wait until locks are released to perform a system reboot

Note that the supervisor cannot distinguish between a first time install of the service or the container being re-created. This means that actions that re-create services will also require a reboot. Ex: restart service, purge data, disable local-mode will all re-create containers and hence require a reboot.