### PR TITLE
Firewall: allow DNS requests from custom Docker bridge networks

### DIFF
--- a/src/lib/firewall.ts
+++ b/src/lib/firewall.ts
@@ -56,10 +56,17 @@ const standardServices: iptables.Rule[] = [
 		target: 'ACCEPT',
 	},
 	{
-		comment: 'DNS',
+		comment: 'DNS from balena0',
 		action: iptables.RuleAction.Append,
 		proto: 'udp',
 		matches: ['--dport 53', '-i balena0'],
+		target: 'ACCEPT',
+	},
+	{
+		comment: 'DNS from custom Engine networks',
+		action: iptables.RuleAction.Append,
+		proto: 'udp',
+		matches: ['--dport 53', '-i br+'],
 		target: 'ACCEPT',
 	},
 ];


### PR DESCRIPTION
We only allow DNS requests through `balena0` interface, but this is the default Docker bridge which is used for containers that don't have a custom bridge. However, the Supervisor creates a custom bridge for all containers unless another network mode is specified. This custom bridge corresponds to a `br-xxxxx` interface on host, and is entirely separate from `balena0`. Therefore when FIREWALL_MODE is enabled, DNS requests aren't actually allowed through due to them not going through `balena0`.

This patch allows DNS requests through `br-xxxxx` custom bridge interfaces, as defined by the rule:
```
{
        comment: 'DNS from custom Engine networks',
	action: iptables.RuleAction.Append,
	proto: 'udp',
	matches: ['--dport 53', '-i br+'],
	target: 'ACCEPT',
}
```
`br+` indicates that any interface beginning with `br` works, although I'm unsure as to the operational security of this. EDIT: After discussion, no operational security risks were brought up.

Change-type: patch