### PR TITLE
WIP: Remove DNS firewall rules

### DIFF
--- a/src/lib/firewall.ts
+++ b/src/lib/firewall.ts
@@ -55,20 +55,6 @@ const standardServices: iptables.Rule[] = [
 		proto: 'icmp',
 		target: 'ACCEPT',
 	},
-	{
-		comment: 'DNS from balena0',
-		action: iptables.RuleAction.Append,
-		proto: 'udp',
-		matches: ['--dport 53', '-i balena0'],
-		target: 'ACCEPT',
-	},
-	{
-		comment: 'DNS from custom Engine networks',
-		action: iptables.RuleAction.Append,
-		proto: 'udp',
-		matches: ['--dport 53', '-i br+'],
-		target: 'ACCEPT',
-	},
 ];
 
 const standardPolicy: iptables.Rule[] = [

--- a/test/integration/lib/firewall.spec.ts
+++ b/test/integration/lib/firewall.spec.ts
@@ -352,30 +352,6 @@ describe('lib/firewall', function () {
 			});
 		};
 
-		it('should have a rule to allow DNS traffic from the balena0 interface', async () => {
-			await iptablesMock.whilstMocked(
-				async ({ hasAppliedRules, expectRule }) => {
-					// set the firewall to be on...
-					await config.set({ firewallMode: 'on' });
-					await hasAppliedRules;
-
-					[4, 6].forEach((family: 4 | 6) => {
-						// expect that we have a rule to allow DNS access...
-						checkForRules(
-							{
-								family,
-								target: 'ACCEPT',
-								chain: 'BALENA-FIREWALL',
-								proto: 'udp',
-								matches: ['--dport 53', '-i balena0'],
-							},
-							expectRule,
-						);
-					});
-				},
-			);
-		});
-
 		it('should have a rule to allow SSH traffic any interface', async () => {
 			await iptablesMock.whilstMocked(
 				async ({ hasAppliedRules, expectRule }) => {


### PR DESCRIPTION
The Engine uses dnsmasq for DNS resolution since OS v2.0-beta.1, by passing the dnsmasq IP using `--dns` when starting up balenad. It is less complicated to have dnsmasq handle DNS resolution; the firewall adding DNS rules to iptables is overly complex with an unclear & undocumented reason as to why.

"WIP" indicates that this commit is under consideration for its security impact.

Change-type: patch