### PR TITLE
Use updateLock.takeLock for all locking actions

### DIFF
--- a/test/integration/device-api/actions.spec.ts
+++ b/test/integration/device-api/actions.spec.ts
@@ -14,42 +14,11 @@ import * as actions from '~/src/device-api/actions';
 import * as TargetState from '~/src/api-binder/poll';
 import * as updateLock from '~/lib/update-lock';
 import { pathOnRoot } from '~/lib/host-utils';
-import { exec } from '~/lib/fs-utils';
 import * as lockfile from '~/lib/lockfile';
 import { cleanupDocker } from '~/test-lib/docker-helper';
+import { dbusSend } from '~/test-lib/dbus';
 import { getBlink } from '~/lib/blink';
 import type { Blink } from '~/lib/blink';
-
-export async function dbusSend(
-	dest: string,
-	path: string,
-	message: string,
-	...contents: string[]
-) {
-	const { stdout, stderr } = await exec(
-		[
-			'dbus-send',
-			'--system',
-			`--dest=${dest}`,
-			'--print-reply',
-			path,
-			message,
-			...contents,
-		].join(' '),
-		{ encoding: 'utf8' },
-	);
-
-	if (stderr) {
-		throw new Error(stderr);
-	}
-
-	// Remove first line, trim each line, and join them back together
-	return stdout
-		.split(/\r?\n/)
-		.slice(1)
-		.map((s) => s.trim())
-		.join('');
-}
 
 describe('regenerates API keys', () => {
 	// Stub external dependency - current state report should be tested separately.

--- a/test/lib/dbus.ts
+++ b/test/lib/dbus.ts
@@ -1,0 +1,32 @@
+import { exec } from '~/lib/fs-utils';
+
+export async function dbusSend(
+	dest: string,
+	path: string,
+	message: string,
+	...contents: string[]
+) {
+	const { stdout, stderr } = await exec(
+		[
+			'dbus-send',
+			'--system',
+			`--dest=${dest}`,
+			'--print-reply',
+			path,
+			message,
+			...contents,
+		].join(' '),
+		{ encoding: 'utf8' },
+	);
+
+	if (stderr) {
+		throw new Error(stderr);
+	}
+
+	// Remove first line, trim each line, and join them back together
+	return stdout
+		.split(/\r?\n/)
+		.slice(1)
+		.map((s) => s.trim())
+		.join('');
+}


### PR DESCRIPTION
Take all locks through updateLock.takeLock

updateLock.lock disposes all locks as a final step regardless of
locking success. It also tries to take the lock for every service
under an appId, even if Supervisor locks are already taken for that
service from another context (such as from updateLock.takeLock
which is a state engine step). This latter case can result in
UpdatesLockedError where both the lock already present and the
locking attempt originate from the Supervisor, which is undesireable
as this will lead to updateLock.lock disposing all locks

The solution is this is for any lock-taking mechanism to go through
updateLock.takeLock, which only takes Supervisor locks where not already
taken by the Supervisor. This commit splits out the lock-taking functionality
into a separate function, updateLock.takeLockFor, which takes the locks and
returns the process lock release function, allowing the callee to control
when process locks should be released. This is necessary as updateLock.lock
can call takeLockFor for multiple appIds, and process locks should only
be released after all resources in scope are locked.

Also create a test case for this behavior

Change-type: patch
Signed-off-by: Christina Ying Wang <christina@balena.io>