### PR TITLE
Specify `/tmp/balena|resin` directories as necessary

### DIFF
--- a/docs/update-locking.md
+++ b/docs/update-locking.md
@@ -17,6 +17,8 @@ On devices running Supervisor v13.1.0 or newer, the Supervisor creates lockfiles
 
 ### Location of the lockfile
 
+__Note:__ Trying to remove `/tmp/balena` or legacy `/tmp/resin` directories will result in a `resource busy` error.
+
 On devices running Supervisor v7.22.0 and higher, the lockfile is located at `/tmp/balena/updates.lock`. This lock is cleared automatically when the device reboots, so the user app must take it every time it starts up.
 
 On older devices (with v4.0.0 <= Supervisor version < v7.22.0), the lock is located at `/tmp/resin/resin-updates.lock`. The latest Supervisor versions still take the lock at this legacy path for backwards compatibility.


### PR DESCRIPTION
See: https://forums.balena.io/t/rm-cant-remove-tmp-balena-resource-busy/367888/5
Change-type: patch