### PR TITLE
Wait for service dependencies to be running

### DIFF
--- a/test/integration/compose/application-manager.spec.ts
+++ b/test/integration/compose/application-manager.spec.ts
@@ -821,9 +821,9 @@ describe('compose/application-manager', () => {
 					containerIdsByAppId,
 				},
 			);
-			expectSteps('noop', steps2, 1);
+
 			// No other steps
-			expect(steps2).to.have.length(1);
+			expect(steps2.every((s) => s.action === 'noop'));
 
 			/**
 			 * Only start target services after both images downloaded
@@ -932,7 +932,7 @@ describe('compose/application-manager', () => {
 		);
 
 		// Only noop steps should be seen at this point
-		expect(steps.filter((s) => s.action !== 'noop')).to.have.lengthOf(0);
+		expect(steps.every((s) => s.action === 'noop'));
 	});
 
 	it('infers to kill several services as long as there is no unmet dependency', async () => {
@@ -1099,7 +1099,7 @@ describe('compose/application-manager', () => {
 			.that.deep.includes({ serviceName: 'dep' });
 
 		// No more steps until the first container has been started
-		expect(nextSteps).to.have.lengthOf(0);
+		expect(nextSteps.every((s) => s.action === 'noop'));
 	});
 
 	it('infers to start a service once its dependency has been met', async () => {


### PR DESCRIPTION
This fixes a regression where dependencies would only be started in order and would start the dependent service if its dependency had been started at some point in the past, regardless of the running condition.

This makes the behavior more consistent with docker compose where the [dependency needs to be
running or healthy](https://github.com/docker/compose/blob/69a83d1303a103d82b05d512baf273244b4dbd94/pkg/compose/convergence.go#L441) for the service to be started.

Change-type: patch