### PR TITLE
Stream logs from host os-update.service

### DIFF
--- a/src/logging/monitor.ts
+++ b/src/logging/monitor.ts
@@ -36,6 +36,8 @@ const HOST_SERVICES = [
 	'nvpmodel.service',
 	// Runs at boot time and checks if Orin QSPI is accessible after provisioning
 	'jetson-qspi-manager.service',
+	// os-update service which logs status of HUP and update-balena-supervisor
+	'os-update.service',
 ];
 
 function messageFieldToString(entry: JournalRow['MESSAGE']): string | null {


### PR DESCRIPTION
This service logs the status of HUP and update-balena-supervisor host services. The commit streams the logs from this service to the cloud when an OS / SV update is triggered.

Change-type: patch