### PR TITLE
Switch to image pull if delta failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "copy-webpack-plugin": "^12.0.0",
         "deep-object-diff": "1.1.0",
         "docker-delta": "^4.1.0",
-        "docker-progress": "^5.2.3",
+        "docker-progress": "^5.2.4",
         "dockerode": "^4.0.2",
         "duration-js": "^4.0.0",
         "express": "^4.21.2",
@@ -4794,10 +4794,11 @@
       }
     },
     "node_modules/docker-progress": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/docker-progress/-/docker-progress-5.2.3.tgz",
-      "integrity": "sha512-tsiqpC61pzaDOkKhbvr7ABQB2bL3bx+sVa7r4IZFf3tzwcMIhcU/sr5fqsXOKzIspxiCL+UHNS9gNO5ly9JxWg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/docker-progress/-/docker-progress-5.2.4.tgz",
+      "integrity": "sha512-sgEXTJh78YOj8pIBIzZHLo3KpamJ5N0/3pU7DkpZBBvxZ9PmO0d9ND6x7TExQZf4hgvlFRBS41aN+GHx6vu5KQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/dockerode": "^3.3.23",
         "JSONStream": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "copy-webpack-plugin": "^12.0.0",
     "deep-object-diff": "1.1.0",
     "docker-delta": "^4.1.0",
-    "docker-progress": "^5.2.3",
+    "docker-progress": "^5.2.4",
     "dockerode": "^4.0.2",
     "duration-js": "^4.0.0",
     "express": "^4.21.2",

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -71,6 +71,11 @@ export class InvalidNetGatewayError extends TypedError {}
 export class DeltaStillProcessingError extends TypedError {}
 
 export class DeltaServerError extends StatusError {}
+export class DeltaApplyError extends Error {
+	constructor(message?: string) {
+		super(message);
+	}
+}
 
 export class UpdatesLockedError extends TypedError {}
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -70,6 +70,8 @@ export class InvalidNetGatewayError extends TypedError {}
 
 export class DeltaStillProcessingError extends TypedError {}
 
+export class DeltaServerError extends StatusError {}
+
 export class UpdatesLockedError extends TypedError {}
 
 export function isHttpConflictError(err: { statusCode: number }): boolean {


### PR DESCRIPTION
- Revert to regular pull immediately on HTTP 4xx delta server response when initially requesting the delta resource.
- Retry delta pull DELTA_APPLY_RETRY_COUNT (3) times when there's a delta failure during delta apply, such as in the case of https://github.com/balena-os/balena-engine/issues/244. After retry count, fall back to regular pull. Delta apply occurs with image pull, after successfully requesting the delta resource from the delta server. Errors with delta apply occur before or after image pull, see cases which raise the relevant Engine error [here](https://github.com/balena-os/balena-engine/blob/master/distribution/pull_v2.go#L43)

Change-type: patch
