### PR TITLE
Update supervisor to Node 22

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,8 +1,8 @@
 ARG ARCH=%%BALENA_ARCH%%
 ARG FATRW_VERSION=0.2.21
-ARG NODE="nodejs~=20"
+ARG NODE="nodejs~=22"
 ARG NPM="npm~=10"
-ARG ALPINE_VERSION="3.19"
+ARG ALPINE_VERSION="3.21"
 
 ###################################################
 # Build the supervisor dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@types/memoizee": "^0.4.11",
         "@types/mocha": "^10.0.6",
         "@types/morgan": "^1.9.9",
-        "@types/node": "^20.12.7",
+        "@types/node": "^22.10.6",
         "@types/request": "^2.48.12",
         "@types/rewire": "^2.5.30",
         "@types/rwlock": "^5.0.6",
@@ -1419,13 +1419,21 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "version": "22.10.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.6.tgz",
+      "integrity": "sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.20.0"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@balena/compose": "^3.2.1",
-        "@balena/contrato": "^0.9.4",
+        "@balena/contrato": "^0.12.0",
         "@balena/es-version": "^1.0.3",
         "@balena/lint": "^8.0.2",
         "@types/bluebird": "^3.5.42",
@@ -109,7 +109,7 @@
         "yargs": "^17.7.2"
       },
       "engines": {
-        "node": ">=20 <21",
+        "node": ">=20 <23",
         "npm": ">=10"
       }
     },
@@ -441,23 +441,62 @@
       }
     },
     "node_modules/@balena/contrato": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@balena/contrato/-/contrato-0.9.4.tgz",
-      "integrity": "sha512-zS3RwyYzIu6Db+8F+7yjDE7AlvpEiFvRefu7aMyzV/xouZqsJFRYJjY4j+YRjcsbvvFALl8aUe5U2XIN67HWTQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@balena/contrato/-/contrato-0.12.0.tgz",
+      "integrity": "sha512-0B6mBcGRqIPxgJ8sELd9UQFrXHKwmeZjizLespB92QRpFuVrheMtayYIXjYiJ1jJtp+KA75xwCmgtfOIftL8gg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "debug": "^3.2.6",
         "handlebars": "^4.7.8",
-        "handlebars-async-helpers": "^1.0.4",
-        "js-combinatorics": "^0.5.5",
+        "js-combinatorics": "^2.1.2",
+        "json-schema": "^0.4.0",
         "lodash": "^4.17.19",
-        "object-hash": "^1.3.1",
-        "semver": "^5.7.1",
-        "skhema": "^5.3.2"
+        "object-hash": "^3.0.0",
+        "p-map": "^7.0.3",
+        "promised-handlebars": "^2.0.1",
+        "semver": "^7.6.3"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "node_modules/@balena/contrato/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@balena/contrato/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/@balena/contrato/node_modules/debug": {
@@ -469,19 +508,30 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/@balena/contrato/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@balena/contrato/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
-    "node_modules/@balena/contrato/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+    "node_modules/@balena/contrato/node_modules/p-map": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
       "dev": true,
-      "bin": {
-        "semver": "bin/semver"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@balena/dockerignore": {
@@ -1349,12 +1399,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/json-mask/-/json-mask-2.0.3.tgz",
       "integrity": "sha512-UXsQjNMGVeLzv6gxHdlIzuQrivc92PKFUQelhVvfwiVfjeiW6A0LpgKG2k9TBbPvCDr1BfI/dN6CWHMPXdJ6mA==",
-      "dev": true
-    },
-    "node_modules/@types/json-schema": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-6.0.1.tgz",
-      "integrity": "sha512-vuL/tG01yKO//gmCmnV3OZhx2hs538t+7FpQq//sUV1sF6xiKi5V8F60dvAxe/HkC4+QaMCHqrm/akqlppTAkQ==",
       "dev": true
     },
     "node_modules/@types/JSONStream": {
@@ -3373,12 +3417,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-      "dev": true
-    },
     "node_modules/callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
@@ -3830,29 +3868,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/compute-gcd": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
-      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
-      "dev": true,
-      "dependencies": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
-    },
-    "node_modules/compute-lcm": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
-      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
-      "dev": true,
-      "dependencies": {
-        "compute-gcd": "^1.2.1",
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4172,13 +4187,14 @@
         "node": ">=4"
       }
     },
-    "node_modules/deep-copy": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/deep-copy/-/deep-copy-1.4.2.tgz",
-      "integrity": "sha512-VxZwQ/1+WGQPl5nE67uLhh7OqdrmqI1OazrraO9Bbw/M8Bt6Mol/RxzDA6N6ZgRXpsG/W9PgUj8E1LHHBEq2GQ==",
+    "node_modules/deep-aplus": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/deep-aplus/-/deep-aplus-1.0.4.tgz",
+      "integrity": "sha512-M2leWJ3xdxBxnmCM2xmac7OrB/hdyal+bBMUTfMFmZIfevho1PqKKtFA9dVM05BL5JYlKKHn2s5ga2AjsvcSiA==",
       "dev": true,
-      "engines": {
-        "node": ">=4.0.0"
+      "license": "MIT",
+      "dependencies": {
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "node_modules/deep-eql": {
@@ -4683,15 +4699,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/drange": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
-      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/duplexer": {
@@ -6025,17 +6032,28 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "node_modules/fast-memoize": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
-      "dev": true
-    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.5.tgz",
+      "integrity": "sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -6442,12 +6460,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/format-util": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
-      "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==",
-      "dev": true
     },
     "node_modules/formdata-node": {
       "version": "4.4.1",
@@ -6965,15 +6977,6 @@
       },
       "optionalDependencies": {
         "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/handlebars-async-helpers": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/handlebars-async-helpers/-/handlebars-async-helpers-1.0.6.tgz",
-      "integrity": "sha512-rZd4aNoQQlGBx94TF+jA7a+YKaB0IAFINH5QYBEdd7s7paOvG3ouALGKo2cK7u4Qncy+/fntR1bU3LOiq43WTg==",
-      "dev": true,
-      "peerDependencies": {
-        "handlebars": "4.7.8"
       }
     },
     "node_modules/har-schema": {
@@ -8005,10 +8008,11 @@
       }
     },
     "node_modules/js-combinatorics": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/js-combinatorics/-/js-combinatorics-0.5.5.tgz",
-      "integrity": "sha512-WglFY9EQvwndNhuJLxxyjnC16649lfZly/G3M3zgQMwcWlJDJ0Jn9niPWeYjnLXwWOEycYVxR2Tk98WLeFkrcw==",
-      "dev": true
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/js-combinatorics/-/js-combinatorics-2.1.2.tgz",
+      "integrity": "sha512-/1AY2bYwxajoaKjPzvgQ80U7lcucU71ubzFPVgZGmzbDGn3R18ZQUZfD69+4Idg4JfNcq6trwD6I+dRfVnr/tg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -8086,51 +8090,6 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
-    "node_modules/json-schema-compare": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
-      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.4"
-      }
-    },
-    "node_modules/json-schema-faker": {
-      "version": "0.5.0-rcv.34",
-      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rcv.34.tgz",
-      "integrity": "sha512-Q68XN31eg8rtDNZQpW7f3BrOJxdpBFdPRTmvbn3rex0fI7hrQJGyoqEKb2lb5UiUS+sblOwgKq4aPtdzwHph9Q==",
-      "dev": true,
-      "dependencies": {
-        "json-schema-ref-parser": "^6.1.0",
-        "jsonpath-plus": "^3.0.0",
-        "randexp": "^0.5.3"
-      },
-      "bin": {
-        "jsf": "bin/gen.js"
-      }
-    },
-    "node_modules/json-schema-merge-allof": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
-      "integrity": "sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==",
-      "dev": true,
-      "dependencies": {
-        "compute-lcm": "^1.1.0",
-        "json-schema-compare": "^0.2.2",
-        "lodash": "^4.17.4"
-      }
-    },
-    "node_modules/json-schema-ref-parser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
-      "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-      "dev": true,
-      "dependencies": {
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.12.1",
-        "ono": "^4.0.11"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -8181,15 +8140,6 @@
       "engines": [
         "node >= 0.2.0"
       ]
-    },
-    "node_modules/jsonpath-plus": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-3.0.0.tgz",
-      "integrity": "sha512-WQwgWEBgn+SJU1tlDa/GiY5/ngRpa9yrSj8n4BYPHcwoxTDaMEaYCHMOn42hIHHDd3CrUoRr3+HpsK0hCKoxzA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0"
-      }
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
@@ -8861,6 +8811,13 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -10523,12 +10480,13 @@
       }
     },
     "node_modules/object-hash": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
-      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -10684,15 +10642,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ono": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-      "dev": true,
-      "dependencies": {
-        "format-util": "^1.0.3"
       }
     },
     "node_modules/optionator": {
@@ -11158,6 +11107,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/promised-handlebars": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promised-handlebars/-/promised-handlebars-2.0.1.tgz",
+      "integrity": "sha512-idhuCYZulsjgBssopKqsV6lpJXFEzK+vjoCa+bDmbUG7lUz9kO+25GgcZKw+xbXrPfJxV8PwKrS5CIPmhbLgBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-aplus": "^1.0.2"
+      },
+      "peerDependencies": {
+        "handlebars": "3||4"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -11267,28 +11229,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/randexp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
-      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
-      "dev": true,
-      "dependencies": {
-        "drange": "^1.0.2",
-        "ret": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/randexp/node_modules/ret": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
-      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/randombytes": {
@@ -12172,33 +12112,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/skhema": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/skhema/-/skhema-5.3.4.tgz",
-      "integrity": "sha512-2xYL0EwAjqFfbr414RP/wKfM1fRd30kJAS2RsOA+UDq/vvszZeLXZWK9yTPYrr31rQzrczLMvLuD4z74EC3VBw==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^6.0.1",
-        "ajv": "^6.5.1",
-        "ajv-keywords": "^3.2.0",
-        "deep-copy": "^1.4.2",
-        "fast-memoize": "^2.5.1",
-        "json-schema-faker": "^0.5.0-rc16",
-        "json-schema-merge-allof": "^0.6.0",
-        "lodash": "^4.17.19",
-        "lru-cache": "^5.1.1",
-        "typed-error": "^3.2.0"
-      }
-    },
-    "node_modules/skhema/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
       }
     },
     "node_modules/slash": {
@@ -13795,43 +13708,6 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
-    "node_modules/validate.io-array": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00=",
-      "dev": true
-    },
-    "node_modules/validate.io-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
-      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc=",
-      "dev": true
-    },
-    "node_modules/validate.io-integer": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
-      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
-      "dev": true,
-      "dependencies": {
-        "validate.io-number": "^1.0.3"
-      }
-    },
-    "node_modules/validate.io-integer-array": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
-      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
-      "dev": true,
-      "dependencies": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-integer": "^1.0.4"
-      }
-    },
-    "node_modules/validate.io-number": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg=",
-      "dev": true
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -14378,12 +14254,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
     },
     "node_modules/yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "sqlite3": "^5.1.6"
   },
   "engines": {
-    "node": ">=20 <21",
+    "node": ">=20 <23",
     "npm": ">=10"
   },
   "devDependencies": {
@@ -57,7 +57,7 @@
     "@types/memoizee": "^0.4.11",
     "@types/mocha": "^10.0.6",
     "@types/morgan": "^1.9.9",
-    "@types/node": "^20.12.7",
+    "@types/node": "^22.10.6",
     "@types/request": "^2.48.12",
     "@types/rewire": "^2.5.30",
     "@types/rwlock": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@balena/compose": "^3.2.1",
-    "@balena/contrato": "^0.9.4",
+    "@balena/contrato": "^0.12.0",
     "@balena/es-version": "^1.0.3",
     "@balena/lint": "^8.0.2",
     "@types/bluebird": "^3.5.42",

--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -128,7 +128,7 @@ export function containerContractsFulfilled(
 		].map((c) => new Contract(c)),
 	);
 
-	const solution = blueprint.reproduce(universe);
+	const solution = [...blueprint.reproduce(universe)];
 
 	if (solution.length > 1) {
 		throw new InternalInconsistencyError(


### PR DESCRIPTION
## Release Notes

Updates the balenaSupervisor service to use [Node v22](https://nodejs.org/en/blog/announcements/v22-release-announce) and [Alpine v3.21](https://alpinelinux.org/posts/Alpine-3.21.0-released.html) base image for balenaCloud releases. 

This update should have no impact on features but it should benefit from improvements and security fixes on the aforementioned dependencies.