### PR TITLE
Add Docker network label if custom ipam config

### DIFF
--- a/src/compose/network.ts
+++ b/src/compose/network.ts
@@ -160,6 +160,15 @@ class NetworkImpl implements Network {
 			configOnly: network.config_only || false,
 		};
 
+		// Add label if there's non-default ipam config
+		// e.g. explicitly defined subnet or gateway.
+		// When updating between a release where the ipam config
+		// changes, this label informs the Supervisor that
+		// there's an ipam diff that requires recreating the network.
+		if (net.config.ipam.config.length > 0) {
+			net.config.labels['io.balena.private.ipam.config'] = 'true';
+		}
+
 		return net;
 	}
 

--- a/test/integration/compose/network.spec.ts
+++ b/test/integration/compose/network.spec.ts
@@ -67,6 +67,8 @@ describe('compose/network: integration tests', () => {
 				Labels: {
 					'io.balena.supervised': 'true',
 					'io.balena.app-id': '12345',
+					// This label should be present as we've defined a custom ipam config
+					'io.balena.private.ipam.config': 'true',
 				},
 				Options: {},
 				ConfigOnly: false,


### PR DESCRIPTION
In a target release where the only change is the addition or removal of a custom ipam config, the Supervisor does not recreate the network due to ignoring ipam config differences when comparing current and target network (in network.isEqualConfig). This commit implements the addition of a network label if the target compose object includes a network with custom ipam. With the label, the Supervisor will detect a difference between a network with a custom ipam and a network without, without needing to compare the ipam configs themselves.

This is a major change, as devices running networks with custom ipam configs
will have their services & networks recreated to add the network label.

Closes: #2251
Change-type: major

## Release Notes

This release resolves a bug where a target release with only a network custom IPAM config change does not get applied by the Supervisor.

When receiving a target release with a custom IPAM config, the Supervisor will add the `io.balena.private.ipam.config` label to Docker networks with custom IPAM configs. As a result, these networks will be properly recreated.

This is a major change. Devices that currently have services using networks with custom IPAM configurations will experience:
- A one-time service restart for services dependent on the custom network
- Recreation of affected networks to apply proper IPAM configuration