### PR TITLE
Polling improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "express": "^4.21.2",
         "fork-ts-checker-webpack-plugin": "^9.0.2",
         "fp-ts": "^2.16.5",
-        "got": "14.4.1",
+        "got": "^14.4.6",
         "husky": "^9.1.7",
         "io-ts": "2.2.20",
         "io-ts-reporters": "^2.0.1",
@@ -1225,13 +1225,13 @@
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-6.3.1.tgz",
-      "integrity": "sha512-FX4MfcifwJyFOI2lPoX7PQxCqx8BG1HCho7WdiXwpEQx1Ycij0JxkfYtGK7yqNScrZGSlt6RE6sw8QYoH7eKnQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.0.1.tgz",
+      "integrity": "sha512-QWLl2P+rsCJeofkDNIT3WFmb6NrRud1SUYW8dIhXK/46XFV8Q/g7Bsvib0Askb0reRLe+WYPeeE+l5cH7SlkuQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -7054,24 +7054,23 @@
       }
     },
     "node_modules/got": {
-      "version": "14.4.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-14.4.1.tgz",
-      "integrity": "sha512-IvDJbJBUeexX74xNQuMIVgCRRuNOm5wuK+OC3Dc2pnSoh1AOmgc7JVj7WC+cJ4u0aPcO9KZ2frTXcqK4W/5qTQ==",
+      "version": "14.4.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-14.4.6.tgz",
+      "integrity": "sha512-rnhwfM/PhMNJ1i17k3DuDqgj0cKx3IHxBKVv/WX1uDKqrhi2Gv3l7rhPThR/Cc6uU++dD97W9c8Y0qyw9x0jag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sindresorhus/is": "^6.3.1",
+        "@sindresorhus/is": "^7.0.1",
         "@szmarczak/http-timer": "^5.0.1",
         "cacheable-lookup": "^7.0.0",
         "cacheable-request": "^12.0.1",
         "decompress-response": "^6.0.0",
         "form-data-encoder": "^4.0.2",
-        "get-stream": "^8.0.1",
         "http2-wrapper": "^2.2.1",
         "lowercase-keys": "^3.0.0",
         "p-cancelable": "^4.0.1",
         "responselike": "^3.0.0",
-        "type-fest": "^4.19.0"
+        "type-fest": "^4.26.1"
       },
       "engines": {
         "node": ">=20"
@@ -7110,9 +7109,9 @@
       }
     },
     "node_modules/got/node_modules/type-fest": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.20.0.tgz",
-      "integrity": "sha512-MBh+PHUHHisjXf4tlx0CFWoMdjx8zCMLJHOjnV1prABYZFHqtFOyauCIK2/7w4oIfwkF8iNhLtnJEfVY2vn3iw==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.35.0.tgz",
+      "integrity": "sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "express": "^4.21.2",
     "fork-ts-checker-webpack-plugin": "^9.0.2",
     "fp-ts": "^2.16.5",
-    "got": "14.4.1",
+    "got": "^14.4.6",
     "husky": "^9.1.7",
     "io-ts": "2.2.20",
     "io-ts-reporters": "^2.0.1",

--- a/src/api-binder/index.ts
+++ b/src/api-binder/index.ts
@@ -63,7 +63,7 @@ export async function healthcheck() {
 	}
 
 	// Check last time target state has been polled
-	const timeSinceLastFetch = process.hrtime(TargetState.lastFetch);
+	const timeSinceLastFetch = process.hrtime(TargetState.lastSuccessfulFetch);
 	const timeSinceLastFetchMs =
 		timeSinceLastFetch[0] * 1000 + timeSinceLastFetch[1] / 1e6;
 

--- a/src/api-binder/poll.ts
+++ b/src/api-binder/poll.ts
@@ -87,7 +87,8 @@ const emitTargetState = (
  * We set a value rather then being undeclared because having it undefined
  * adds more overhead to dealing with this value without any benefits.
  */
-export let lastFetch: ReturnType<typeof process.hrtime> = process.hrtime();
+export let lastSuccessfulFetch: ReturnType<typeof process.hrtime> =
+	process.hrtime();
 
 /**
  * Attempts to update the target state
@@ -154,8 +155,6 @@ export const update = async (
 
 		// Emit the target state and update the cache
 		cache.emitted = emitTargetState(cache, force, isFromApi);
-	}).finally(() => {
-		lastFetch = process.hrtime();
 	});
 };
 
@@ -188,6 +187,7 @@ const poll = async (
 		await update();
 		// Reset fetchErrors because we successfuly updated
 		fetchErrors = 0;
+		lastSuccessfulFetch = process.hrtime();
 	} catch {
 		// Exponential back off if request fails
 		pollInterval = Math.min(appUpdatePollInterval, 15000 * 2 ** fetchErrors);

--- a/src/api-binder/poll.ts
+++ b/src/api-binder/poll.ts
@@ -188,7 +188,10 @@ const poll = async (
 		// Reset fetchErrors because we successfuly updated
 		fetchErrors = 0;
 		lastSuccessfulFetch = process.hrtime();
-	} catch {
+	} catch (e) {
+		if (!(e instanceof ApiResponseError)) {
+			log.error('Target state poll failed', e);
+		}
 		// Exponential back off if request fails
 		pollInterval = Math.min(appUpdatePollInterval, 15000 * 2 ** fetchErrors);
 		++fetchErrors;

--- a/test/legacy/10-api-binder.spec.ts
+++ b/test/legacy/10-api-binder.spec.ts
@@ -335,7 +335,7 @@ describe('ApiBinder', () => {
 
 		before(async () => {
 			await initModels(components, '/config-apibinder.json');
-			previousLastFetch = TargetState.lastFetch;
+			previousLastFetch = TargetState.lastSuccessfulFetch;
 		});
 
 		after(async () => {


### PR DESCRIPTION
This PR fixes multiple issues with the target state poll.

- Fixes the polling healthcheck by resetting the polling timer only on a successful poll
- It logs errors that happen during connection establishment
- Temporarily switch to using the default timeout of 59s for the GOT instance when performing the poll

Change-type: patch