### PR TITLE
Reduce happy-eyeballs attempt timeout to 4.5s

### DIFF
--- a/src/api-binder/poll.ts
+++ b/src/api-binder/poll.ts
@@ -120,6 +120,7 @@ export const update = async (
 		const got = await getGotInstance();
 
 		const { statusCode, headers, body } = await got(endpoint, {
+			retry: { limit: 0 },
 			headers: {
 				Authorization: `Bearer ${deviceApiKey}`,
 				'If-None-Match': cache?.etag,

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,8 +3,8 @@ import { set } from '@balena/es-version';
 set('es2022');
 
 import { setDefaultAutoSelectFamilyAttemptTimeout } from 'net';
-// Increase the timeout for the happy eyeballs algorithm to 5000ms to avoid issues on slower networks
-setDefaultAutoSelectFamilyAttemptTimeout(5000);
+// Increase the timeout for the happy eyeballs algorithm to 4500ms to avoid issues on slower networks
+setDefaultAutoSelectFamilyAttemptTimeout(4500);
 
 // Setup MDNS resolution
 import './mdns';


### PR DESCRIPTION
We have observed the previous 5s timeout clashing with the default socket timeout (also 5s) resulting in the socket being closed before even one attempt was finished. On testing any value less than 5s worked but we are reducing to 4.5s that should still be more than enough for most networks (the Node default is 250ms).

Change-type: patch