### PR TITLE
Ensure poll socket timeout is defined early

### DIFF
--- a/src/api-binder/poll.ts
+++ b/src/api-binder/poll.ts
@@ -121,6 +121,7 @@ export const update = async (
 		const got = await getGotInstance();
 
 		const { statusCode, headers, body } = await got(endpoint, {
+			retry: { limit: 0 },
 			agent: {
 				https: new Agent({
 					keepAlive: true,

--- a/src/api-binder/poll.ts
+++ b/src/api-binder/poll.ts
@@ -3,6 +3,7 @@ import url from 'url';
 import { setTimeout } from 'timers/promises';
 import Bluebird from 'bluebird';
 import type StrictEventEmitter from 'strict-event-emitter-types';
+import { Agent } from 'https';
 
 import type { TargetState } from '../types/state';
 import { InternalInconsistencyError } from '../lib/errors';
@@ -120,6 +121,12 @@ export const update = async (
 		const got = await getGotInstance();
 
 		const { statusCode, headers, body } = await got(endpoint, {
+			agent: {
+				https: new Agent({
+					keepAlive: true,
+					timeout: apiRequestTimeout,
+				}),
+			},
 			headers: {
 				Authorization: `Bearer ${deviceApiKey}`,
 				'If-None-Match': cache?.etag,


### PR DESCRIPTION
We have observed that even when setting the socket timeout on the state poll https request, the timeout is only applied once the socket is connected. This causes issues with Node's auto family selection (happy eyeballs), as the default https timeout is 5s which means that larger [auto select attempt timeout](https://nodejs.org/docs/latest-v22.x/api/net.html#netgetdefaultautoselectfamilyattempttimeout) may result in the socket timing out before all connection attempts have been tried.

This commit sets a different https Agent for state polling, with a timeout matching the `apiRequestTimeout` used for other request events.

Change-type: patch