### PR TITLE
Fix search for app leftover locks

### DIFF
--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -187,8 +187,12 @@ export async function inferNextSteps(
 	const currentAppIds = Object.keys(currentApps).map((i) => parseInt(i, 10));
 	const targetAppIds = Object.keys(targetApps).map((i) => parseInt(i, 10));
 
-	const withLeftoverLocks = await Promise.all(
-		currentAppIds.map((id) => hasLeftoverLocks(id)),
+	const withLeftoverLocks = Object.fromEntries(
+		await Promise.all(
+			currentAppIds.map(
+				async (id) => [id, await hasLeftoverLocks(id)] as [number, boolean],
+			),
+		),
 	);
 	const bootTime = getBootTime();
 


### PR DESCRIPTION
The leftover locks search was creating an array rather than an object keyed by the appId. This could affect the lock cleanup and make leftover locks from one app affect the install of the app in local mode.

Change-type: patch
