### PR TITLE
Simplify contract validation module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@balena/compose": "^6.0.0",
-        "@balena/contrato": "^0.12.0",
+        "@balena/contrato": "^0.13.0",
         "@balena/es-version": "^1.0.3",
         "@balena/lint": "^8.0.2",
         "@balena/sbvr-types": "^9.1.0",
@@ -460,9 +460,9 @@
       }
     },
     "node_modules/@balena/contrato": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@balena/contrato/-/contrato-0.12.0.tgz",
-      "integrity": "sha512-0B6mBcGRqIPxgJ8sELd9UQFrXHKwmeZjizLespB92QRpFuVrheMtayYIXjYiJ1jJtp+KA75xwCmgtfOIftL8gg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@balena/contrato/-/contrato-0.13.0.tgz",
+      "integrity": "sha512-toDzvrJokqz28We9jZCbepqC/VLy22bo85ZqzfAlLqIKmfanT3VyxkbGumpDbbb9Ra31Y2h4PxkoFn+UtmGA0g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@balena/compose": "^6.0.0",
-    "@balena/contrato": "^0.12.0",
+    "@balena/contrato": "^0.13.0",
     "@balena/es-version": "^1.0.3",
     "@balena/lint": "^8.0.2",
     "@balena/sbvr-types": "^9.1.0",


### PR DESCRIPTION
Use `satisfiesChildContract` instead of Blueprints as the previous implementation did.

Change-type: patch