### PR TITLE
Support target state apply cancellation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -94,10 +94,11 @@ Triggers a check for the target state of configurations and app services. Option
 Responds with an empty 204 (No Content) response.
 
 #### Request body
-Can be a JSON object with a `force` property. If this property is true, the update lock will be overridden.
+Can be a JSON object with `force` and `cancel` properties. If `force` is true, update locks will be overridden by the Supervisor. If `cancel` is true, the Supervisor will abort its current state apply operation to apply the most up-to-date target state. This is useful for interrupting a long operation (e.g. image pull).
 ```json
 {
-	"force": true
+	"force": true,
+	"cancel": true
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "copy-webpack-plugin": "^12.0.0",
         "deep-object-diff": "1.1.0",
         "docker-delta": "^4.1.0",
-        "docker-progress": "^5.2.4",
+        "docker-progress": "^5.3.1",
         "dockerode": "^4.0.2",
         "duration-js": "^4.0.0",
         "express": "^4.21.2",
@@ -4794,9 +4794,9 @@
       }
     },
     "node_modules/docker-progress": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/docker-progress/-/docker-progress-5.2.4.tgz",
-      "integrity": "sha512-sgEXTJh78YOj8pIBIzZHLo3KpamJ5N0/3pU7DkpZBBvxZ9PmO0d9ND6x7TExQZf4hgvlFRBS41aN+GHx6vu5KQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/docker-progress/-/docker-progress-5.3.1.tgz",
+      "integrity": "sha512-vU9p7CYib4sHn2kXdfwLKO6aQTE8JaxrOCKXiieRCpzAgJfyVRjaNauCILvtmraZDRhh/x4gL8MWwxlrm5AyGg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4806,6 +4806,10 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "docker-modem": ">=3.0.3",
+        "dockerode": ">=3.3.1"
       }
     },
     "node_modules/docker-toolbelt": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "copy-webpack-plugin": "^12.0.0",
     "deep-object-diff": "1.1.0",
     "docker-delta": "^4.1.0",
-    "docker-progress": "^5.2.4",
+    "docker-progress": "^5.3.1",
     "dockerode": "^4.0.2",
     "duration-js": "^4.0.0",
     "express": "^4.21.2",

--- a/src/api-binder/index.ts
+++ b/src/api-binder/index.ts
@@ -157,19 +157,19 @@ export async function start() {
 	// Update and apply new target state
 	TargetState.emitter.on(
 		'target-state-update',
-		async (targetState, force, isFromApi) => {
+		async (targetState, force, isFromApi, cancel) => {
 			try {
 				await deviceState.setTarget(targetState);
-				deviceState.triggerApplyTarget({ force, isFromApi });
+				deviceState.triggerApplyTarget({ force, isFromApi, cancel });
 			} catch (err) {
 				handleTargetUpdateError(err);
 			}
 		},
 	);
 	// Apply new target state
-	TargetState.emitter.on('target-state-apply', (force, isFromApi) => {
+	TargetState.emitter.on('target-state-apply', (force, isFromApi, cancel) => {
 		try {
-			deviceState.triggerApplyTarget({ force, isFromApi });
+			deviceState.triggerApplyTarget({ force, isFromApi, cancel });
 		} catch (err) {
 			handleTargetUpdateError(err);
 		}

--- a/src/compose/app.ts
+++ b/src/compose/app.ts
@@ -670,6 +670,7 @@ class AppImpl implements App {
 				context.networkPairs,
 				context.volumePairs,
 				context.servicePairs,
+				context.abortSignal,
 			);
 		} else {
 			// This service is in both current & target so requires an update,
@@ -730,6 +731,7 @@ class AppImpl implements App {
 				servicesLocked,
 				services: this.services.concat(context.targetApp.services),
 				appsToLock: context.appsToLock,
+				abortSignal: context.abortSignal,
 			});
 		}
 	}
@@ -839,6 +841,7 @@ class AppImpl implements App {
 		networkPairs: Array<ChangingPair<Network>>,
 		volumePairs: Array<ChangingPair<Volume>>,
 		servicePairs: Array<ChangingPair<Service>>,
+		abortSignal: AbortSignal,
 	): CompositionStep[] {
 		if (
 			needsDownload &&
@@ -849,6 +852,7 @@ class AppImpl implements App {
 				generateStep('fetch', {
 					image: imageManager.imageFromService(target),
 					serviceName: target.serviceName,
+					abortSignal,
 				}),
 			];
 		} else if (target != null) {

--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -117,9 +117,17 @@ function reportCurrentState(data?: Partial<InstancedAppState>) {
 export async function getRequiredSteps(
 	currentApps: InstancedAppState,
 	targetApps: InstancedAppState,
-	keepImages?: boolean,
-	keepVolumes?: boolean,
-	force: boolean = false,
+	{
+		keepImages,
+		keepVolumes,
+		force = false,
+		abortSignal,
+	}: {
+		keepImages?: boolean;
+		keepVolumes?: boolean;
+		force?: boolean;
+		abortSignal: AbortSignal;
+	},
 ): Promise<CompositionStep[]> {
 	// get some required data
 	const [downloading, availableImages, { localMode, delta }] =
@@ -153,19 +161,21 @@ export async function getRequiredSteps(
 		containerIdsByAppId,
 		appLocks: lockRegistry,
 		rebootBreadcrumbSet,
+		abortSignal,
 	});
 }
 
 interface InferNextOpts {
-	keepImages: boolean;
-	keepVolumes: boolean;
-	delta: boolean;
-	force: boolean;
-	downloading: UpdateState['downloading'];
-	availableImages: UpdateState['availableImages'];
-	containerIdsByAppId: { [appId: number]: UpdateState['containerIds'] };
-	appLocks: LockRegistry;
-	rebootBreadcrumbSet: boolean;
+	keepImages?: boolean;
+	keepVolumes?: boolean;
+	delta?: boolean;
+	force?: boolean;
+	downloading?: UpdateState['downloading'];
+	availableImages?: UpdateState['availableImages'];
+	containerIdsByAppId?: { [appId: number]: UpdateState['containerIds'] };
+	appLocks?: LockRegistry;
+	rebootBreadcrumbSet?: boolean;
+	abortSignal: AbortSignal;
 }
 
 // Calculate the required steps from the current to the target state
@@ -182,7 +192,8 @@ export async function inferNextSteps(
 		containerIdsByAppId = {},
 		appLocks = {},
 		rebootBreadcrumbSet = false,
-	}: Partial<InferNextOpts>,
+		abortSignal,
+	}: InferNextOpts,
 ) {
 	const currentAppIds = Object.keys(currentApps).map((i) => parseInt(i, 10));
 	const targetAppIds = Object.keys(targetApps).map((i) => parseInt(i, 10));
@@ -258,6 +269,7 @@ export async function inferNextSteps(
 							hasLeftoverLocks: withLeftoverLocks[id],
 							rebootBreadcrumbSet,
 							bootTime,
+							abortSignal,
 						},
 						targetApps[id],
 					),
@@ -276,6 +288,7 @@ export async function inferNextSteps(
 						hasLeftoverLocks: withLeftoverLocks[id],
 						rebootBreadcrumbSet,
 						bootTime,
+						abortSignal,
 					}),
 				);
 			}
@@ -304,6 +317,7 @@ export async function inferNextSteps(
 							hasLeftoverLocks: false,
 							rebootBreadcrumbSet,
 							bootTime,
+							abortSignal,
 						},
 						targetApps[id],
 					),

--- a/src/compose/composition-steps.ts
+++ b/src/compose/composition-steps.ts
@@ -115,6 +115,7 @@ export function getExecutors(app: { callbacks: CompositionCallbacks }) {
 					}
 				},
 				step.serviceName,
+				step.abortSignal,
 			);
 		},
 		removeImage: async (step) => {

--- a/src/compose/images.ts
+++ b/src/compose/images.ts
@@ -196,6 +196,14 @@ export async function triggerFetch(
 		});
 	};
 
+	// Remove image task on fetch abort to prevent noop loop
+	abortSignal.onabort = () => {
+		reportEvent('finish', {
+			...image,
+			status: 'Downloading',
+		});
+	};
+
 	let success: boolean;
 	try {
 		const imageName = normalise(image.name);

--- a/src/compose/types/app.ts
+++ b/src/compose/types/app.ts
@@ -14,6 +14,7 @@ export interface UpdateState {
 	force: boolean;
 	rebootBreadcrumbSet: boolean;
 	bootTime: Date;
+	abortSignal: AbortSignal;
 }
 
 export interface App {

--- a/src/compose/types/composition-step.ts
+++ b/src/compose/types/composition-step.ts
@@ -45,6 +45,7 @@ export interface CompositionStepArgs {
 	fetch: {
 		image: Image;
 		serviceName: string;
+		abortSignal: AbortSignal;
 	};
 	removeImage: {
 		image: Image;

--- a/src/compose/update-strategies.ts
+++ b/src/compose/update-strategies.ts
@@ -16,6 +16,7 @@ export interface StrategyContext {
 	services: Service[];
 	servicesLocked: boolean;
 	appsToLock: AppsToLockMap;
+	abortSignal: AbortSignal;
 }
 
 function generateLockThenKillStep(
@@ -44,6 +45,7 @@ export function getStepsFromStrategy(
 					generateStep('fetch', {
 						image: imageManager.imageFromService(context.target),
 						serviceName: context.target.serviceName,
+						abortSignal: context.abortSignal,
 					}),
 				];
 			} else if (context.dependenciesMetForKill) {
@@ -71,6 +73,7 @@ export function getStepsFromStrategy(
 					generateStep('fetch', {
 						image: imageManager.imageFromService(context.target),
 						serviceName: context.target.serviceName,
+						abortSignal: context.abortSignal,
 					}),
 				];
 			} else if (context.needsSpecialKill && context.dependenciesMetForKill) {

--- a/src/device-api/actions.ts
+++ b/src/device-api/actions.ts
@@ -333,11 +333,14 @@ export const executeServiceAction = async ({
  * Used by:
  * - POST /v1/update
  */
-export const updateTarget = async (force: boolean = false) => {
+export const updateTarget = async (
+	force: boolean = false,
+	cancel: boolean = false,
+) => {
 	eventTracker.track('Update notification');
 
 	if (force || (await config.get('instantUpdates'))) {
-		TargetState.update(force, true).catch(_.noop);
+		TargetState.update(force, true, cancel).catch(_.noop);
 		return true;
 	}
 

--- a/src/device-api/v1.ts
+++ b/src/device-api/v1.ts
@@ -146,8 +146,9 @@ router.post('/v1/purge', (req: AuthorizedRequest, res, next) => {
 
 router.post('/v1/update', async (req, res, next) => {
 	const force = checkTruthy(req.body.force);
+	const cancel = checkTruthy(req.body.cancel);
 	try {
-		const result = await actions.updateTarget(force);
+		const result = await actions.updateTarget(force, cancel);
 		return res.sendStatus(result ? 204 : 202);
 	} catch (e: unknown) {
 		next(e);

--- a/src/device-state/index.ts
+++ b/src/device-state/index.ts
@@ -92,6 +92,9 @@ let applyInProgress = false;
 export let connected: boolean;
 export let lastSuccessfulUpdate: number | null = null;
 
+// Controls cancelling of in-progress steps such as fetches
+let abortController: AbortController | null = null;
+
 events.on('error', (err) => log.error('deviceState error: ', err));
 events.on('apply-target-state-end', function (err) {
 	if (err != null) {
@@ -588,7 +591,17 @@ function applyError(
 	}
 }
 
-// We define this function this way so we can mock it in the tests
+interface ApplyTargetOpts {
+	force?: boolean;
+	initial?: boolean;
+	intermediate?: boolean;
+	nextDelay?: number;
+	retryCount?: number;
+	keepVolumes?: boolean;
+	// All target states should be abortable, so abortSignal is non-optional
+	abortSignal: AbortSignal;
+}
+
 export const applyTarget = async ({
 	force = false,
 	initial = false,
@@ -596,7 +609,8 @@ export const applyTarget = async ({
 	nextDelay = 200,
 	retryCount = 0,
 	keepVolumes = undefined as boolean | undefined,
-} = {}) => {
+	abortSignal,
+}: ApplyTargetOpts) => {
 	if (!intermediate) {
 		await applyBlocker;
 	}
@@ -627,12 +641,15 @@ export const applyTarget = async ({
 			const appSteps = await applicationManager.getRequiredSteps(
 				currentState.local.apps,
 				targetState.local.apps,
-				// Do not remove images while applying an intermediate state
-				// if not applying intermediate, we let getRequired steps set
-				// the value
-				intermediate || undefined,
-				keepVolumes,
-				force,
+				{
+					// Do not remove images while applying an intermediate state
+					// if not applying intermediate, we let getRequired steps set
+					// the value
+					keepImages: intermediate || undefined,
+					keepVolumes,
+					force,
+					abortSignal,
+				},
 			);
 
 			if (_.isEmpty(appSteps)) {
@@ -703,6 +720,7 @@ export const applyTarget = async ({
 				nextDelay,
 				retryCount,
 				keepVolumes,
+				abortSignal,
 			});
 		} catch (e: any) {
 			if (e instanceof UpdatesLockedError) {
@@ -754,10 +772,15 @@ export function triggerApplyTarget({
 				// previously setup a delay)
 				cancelDelay?.();
 			}
+			// TODO: If there's an apply in progress and we get a new target state,
+			// abort the current operation
+			if (abortController) {
+				abortController.abort();
+				abortController = null;
+			}
 		} else {
 			// If a delay has been set it's because we need to hold off before applying again,
-			// so we need to respect the maximum delay that has
-			// been passed
+			// so we need to respect the maximum delay that has been passed
 			if (scheduledApply.delay === undefined || isNaN(scheduledApply.delay)) {
 				log.debug(
 					`Tried to apply target with invalid delay: ${scheduledApply.delay}`,
@@ -775,6 +798,8 @@ export function triggerApplyTarget({
 	}
 	applyCancelled = false;
 	applyInProgress = true;
+	// Create new abort controller for this apply trigger
+	abortController = new AbortController();
 	void new Promise((resolve, reject) => {
 		void setTimeout(delay).then(resolve);
 		cancelDelay = reject;
@@ -790,9 +815,20 @@ export function triggerApplyTarget({
 			}
 			lastApplyStart = process.hrtime();
 			log.info('Applying target state');
-			return applyTarget({ force, initial });
+			if (!abortController) {
+				throw new InternalInconsistencyError(
+					'Attempting to apply target state without an abort controller',
+				);
+			}
+			return applyTarget({
+				force,
+				initial,
+				abortSignal: abortController.signal,
+			});
 		})
 		.finally(() => {
+			// Clean up abort controller
+			abortController = null;
 			applyInProgress = false;
 			reportCurrentState();
 			if (scheduledApply != null) {
@@ -807,6 +843,10 @@ export async function applyIntermediateTarget(
 	{ force = false, keepVolumes = undefined as boolean | undefined } = {},
 ) {
 	return pausingApply(async () => {
+		// Our current usage of intermediate state doesn't necessitate
+		// making intermediate state apply operations cancellable, which
+		// is why there's no public interface for aborting intermediate applies.
+		const intermediateAbortController = new AbortController();
 		// TODO: Make sure we don't accidentally overwrite this
 		TargetState.setIntermediateTarget(intermediate);
 		applyInProgress = true;
@@ -814,9 +854,15 @@ export async function applyIntermediateTarget(
 			intermediate: true,
 			force,
 			keepVolumes,
-		}).then(() => {
-			TargetState.setIntermediateTarget(null);
-			applyInProgress = false;
-		});
+			abortSignal: intermediateAbortController.signal,
+		})
+			.catch((err) => {
+				intermediateAbortController.abort();
+				throw err;
+			})
+			.finally(() => {
+				TargetState.setIntermediateTarget(null);
+				applyInProgress = false;
+			});
 	});
 }

--- a/test/integration/compose/application-manager.spec.ts
+++ b/test/integration/compose/application-manager.spec.ts
@@ -83,6 +83,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -119,6 +120,7 @@ describe('compose/application-manager', () => {
 						},
 					},
 				},
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -150,6 +152,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -181,6 +184,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -237,6 +241,7 @@ describe('compose/application-manager', () => {
 						},
 					},
 				},
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -295,6 +300,7 @@ describe('compose/application-manager', () => {
 						},
 					},
 				},
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -343,6 +349,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -434,6 +441,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			// There should be two noop steps, one for target service which is still downloading,
@@ -487,6 +495,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			// Service `old` is safe to kill after download for `new` has completed
@@ -540,6 +549,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			// Service `new` should be fetched
@@ -577,6 +587,7 @@ describe('compose/application-manager', () => {
 					downloading: ['image-new'],
 					availableImages: c2.availableImages,
 					containerIdsByAppId: c2.containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 			// Noop while service `new` is downloading
@@ -619,6 +630,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			// Service `new` should be started
@@ -668,6 +680,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			// Service `new` should be fetched
@@ -705,6 +718,7 @@ describe('compose/application-manager', () => {
 					downloading: ['image-new'],
 					availableImages: c2.availableImages,
 					containerIdsByAppId: c2.containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 			// Noop while service `new` is downloading
@@ -748,6 +762,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			// Service `new` should be started
@@ -798,6 +813,7 @@ describe('compose/application-manager', () => {
 					downloading: ['image-one', 'image-two'],
 					availableImages,
 					containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('noop', steps, 2);
@@ -819,6 +835,7 @@ describe('compose/application-manager', () => {
 						}),
 					],
 					containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 
@@ -852,6 +869,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('start', steps3, 2);
@@ -928,6 +946,7 @@ describe('compose/application-manager', () => {
 						},
 					},
 				},
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1016,6 +1035,7 @@ describe('compose/application-manager', () => {
 						},
 					},
 				},
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1089,6 +1109,7 @@ describe('compose/application-manager', () => {
 						},
 					},
 				},
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1174,6 +1195,7 @@ describe('compose/application-manager', () => {
 						},
 					},
 				},
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1229,6 +1251,7 @@ describe('compose/application-manager', () => {
 						},
 					},
 				},
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1264,6 +1287,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1287,6 +1311,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1311,6 +1336,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1336,6 +1362,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			});
 		expect(ensureNetworkStep).to.deep.include({
 			action: 'ensureSupervisorNetwork',
@@ -1373,6 +1400,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1420,6 +1448,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1474,6 +1503,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1529,6 +1559,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			},
 		);
 		expect(steps.filter((s) => s.action === 'removeImage')).to.be.empty;
@@ -1576,6 +1607,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1631,6 +1663,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			},
 		);
 		expect(steps.filter((s) => s.action === 'removeImage')).to.be.empty;
@@ -1664,6 +1697,7 @@ describe('compose/application-manager', () => {
 				downloading,
 				availableImages,
 				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1751,6 +1785,7 @@ describe('compose/application-manager', () => {
 						},
 					},
 				},
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1844,6 +1879,7 @@ describe('compose/application-manager', () => {
 						},
 					},
 				},
+				abortSignal: new AbortController().signal,
 			},
 		);
 
@@ -1893,6 +1929,7 @@ describe('compose/application-manager', () => {
 					downloading,
 					availableImages,
 					containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 			const [takeLockStep] = expectSteps('takeLock', steps, 1, 1);
@@ -1916,6 +1953,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('kill', steps2, 2);
@@ -1956,6 +1994,7 @@ describe('compose/application-manager', () => {
 					downloading,
 					availableImages,
 					containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 			const [takeLockStep] = expectSteps('takeLock', steps, 1, 1);
@@ -1979,6 +2018,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('stop', steps2, 2);
@@ -2019,6 +2059,7 @@ describe('compose/application-manager', () => {
 					downloading,
 					availableImages,
 					containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 			const [takeLockStep] = expectSteps('takeLock', steps, 1, 1);
@@ -2042,6 +2083,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('start', steps2, 2);
@@ -2100,6 +2142,7 @@ describe('compose/application-manager', () => {
 					downloading,
 					availableImages,
 					containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 			// No matter the number of services, we should see a single takeLock for all services
@@ -2165,6 +2208,7 @@ describe('compose/application-manager', () => {
 					downloading: [],
 					availableImages: [],
 					containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('fetch', steps, 2);
@@ -2177,6 +2221,7 @@ describe('compose/application-manager', () => {
 					downloading: ['one', 'two'],
 					availableImages: [],
 					containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('noop', steps2, 2);
@@ -2189,6 +2234,7 @@ describe('compose/application-manager', () => {
 					downloading,
 					availableImages,
 					containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 			const [takeLockStep] = expectSteps('takeLock', steps3, 1);
@@ -2212,6 +2258,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('kill', steps4, 2);
@@ -2265,6 +2312,7 @@ describe('compose/application-manager', () => {
 					downloading: ['one', 'two'],
 					availableImages,
 					containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 			const [takeLockStep] = expectSteps('takeLock', steps, 1, 1);
@@ -2288,6 +2336,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('kill', steps2, 2);
@@ -2328,6 +2377,7 @@ describe('compose/application-manager', () => {
 					downloading,
 					availableImages,
 					containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 			const [takeLockStep] = expectSteps('takeLock', steps, 1, 1);
@@ -2351,6 +2401,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('kill', steps2);
@@ -2380,6 +2431,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('removeNetwork', steps3);
@@ -2429,6 +2481,7 @@ describe('compose/application-manager', () => {
 					downloading,
 					availableImages,
 					containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 			const [takeLockStep] = expectSteps('takeLock', steps, 1, 1);
@@ -2452,6 +2505,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('kill', steps2, 1);
@@ -2481,6 +2535,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('removeNetwork', steps3);
@@ -2526,6 +2581,7 @@ describe('compose/application-manager', () => {
 					downloading,
 					availableImages,
 					containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 			const [takeLockStep] = expectSteps('takeLock', steps, 1, 1);
@@ -2549,6 +2605,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('kill', steps2, 1);
@@ -2574,6 +2631,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			expectSteps('removeVolume', steps3);
@@ -2612,6 +2670,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				},
 			);
 			const [releaseLockStep] = expectSteps('releaseLock', steps, 1, 1);
@@ -3110,6 +3169,7 @@ describe('compose/application-manager', () => {
 							},
 						},
 					},
+					abortSignal: new AbortController().signal,
 				});
 
 			[startStep1, startStep2, startStep3, startStep4].forEach((step) => {
@@ -3133,6 +3193,7 @@ describe('compose/application-manager', () => {
 					downloading,
 					availableImages,
 					containerIdsByAppId,
+					abortSignal: new AbortController().signal,
 				},
 			);
 

--- a/test/integration/device-api/actions.spec.ts
+++ b/test/integration/device-api/actions.spec.ts
@@ -1285,6 +1285,12 @@ describe('updates target state cache', () => {
 		await actions.updateTarget(false);
 		expect(updateStub).to.not.have.been.called;
 	});
+
+	it('updates target state cache with cancel flag', async () => {
+		await config.set({ instantUpdates: true });
+		await actions.updateTarget(false, true);
+		expect(updateStub).to.have.been.calledWith(false, true);
+	});
 });
 
 describe('identifies device', () => {

--- a/test/integration/device-api/v1.spec.ts
+++ b/test/integration/device-api/v1.spec.ts
@@ -670,6 +670,14 @@ describe('device-api/v1', () => {
 				.post('/v1/update')
 				.set('Authorization', `Bearer ${await apiKeys.getGlobalApiKey()}`);
 			expect(updateTargetStub.lastCall.firstArg).to.be.false;
+
+			// Parses cancel: true
+			await request(api)
+				.post('/v1/update')
+				.send({ cancel: true })
+				.set('Authorization', `Bearer ${await apiKeys.getGlobalApiKey()}`);
+			expect(updateTargetStub.lastCall.args[1]).to.be.true;
+			updateTargetStub.resetHistory();
 		});
 
 		it('responds with 204 if update triggered', async () => {

--- a/test/integration/device-state.spec.ts
+++ b/test/integration/device-state.spec.ts
@@ -251,6 +251,7 @@ describe('device-state', () => {
 		expect(applyTargetStub).to.be.calledWith({
 			force: true,
 			initial: false,
+			abortSignal: new AbortController().signal,
 		});
 		applyTargetStub.restore();
 	});

--- a/test/unit/compose/app.spec.ts
+++ b/test/unit/compose/app.spec.ts
@@ -23,6 +23,7 @@ const defaultContext = {
 	hasLeftoverLocks: false,
 	rebootBreadcrumbSet: false,
 	bootTime: new Date(Date.now() - 30 * 60 * 1000), // 30 minutes ago
+	abortSignal: new AbortController().signal,
 };
 
 const mockLock: Lock = {


### PR DESCRIPTION
## Description

Support target state apply cancellation
    
The current target state apply is cancelled when either:
    - /v1/update is called with cancel: true
    - A different target state is received from the cloud (with a non-304 status)
    
Following apply cancellation, a target state apply is re-triggered. This ensures
that the user can force a device out of a dead-locked situation where a long-running
task such as an image fetch fails to cede control back to the Supervisor, which is
the behavior observed in an Engine bug with infinite pull retries with a bad network. This
bug has been observed to affect users on support.

This Supervisor change is a way to work around the above described Engine bug, but a proper fix
should come from the Engine.

## Type of change

Minor - but should it be major?

## How Has This Been Tested?

Tested on-device by changing a config var during an image pull, as well as calling Supervisor API's POST /v1/update with cancel: true. Both resulted in pull cancellation and retry.
