### PR TITLE
Remove unsupported fields from contract requirements

### DIFF
--- a/test/integration/device-state.spec.ts
+++ b/test/integration/device-state.spec.ts
@@ -411,6 +411,7 @@ describe('device-state', () => {
 													{
 														type: 'arch.sw',
 														slug: 'armv7hf',
+														name: 'armv7hf',
 													},
 												],
 											},

--- a/test/unit/lib/contracts.spec.ts
+++ b/test/unit/lib/contracts.spec.ts
@@ -79,6 +79,40 @@ describe('lib/contracts', () => {
 				}),
 			).to.throw();
 		});
+
+		it('should ignore unsupported requirement properties', () => {
+			expect(
+				contracts.parseContract({
+					slug: 'user-container',
+					requires: [
+						{
+							type: 'sw.l4t',
+							version: '32.2',
+							name: 'l4t-version',
+							unsupported: 'something',
+						},
+						{
+							type: 'hw.device-type',
+							slug: 'raspberrypi3',
+							name: 'raspberrypi3',
+						},
+					],
+				}),
+			).to.deep.equal({
+				type: 'sw.container',
+				slug: 'user-container',
+				requires: [
+					{
+						type: 'sw.l4t',
+						version: '32.2',
+					},
+					{
+						type: 'hw.device-type',
+						slug: 'raspberrypi3',
+					},
+				],
+			});
+		});
 	});
 
 	describe('Requirement resolution', () => {
@@ -287,6 +321,25 @@ describe('lib/contracts', () => {
 			)
 				.to.have.property('valid')
 				.that.equals(false);
+
+			expect(
+				contracts.containerContractsFulfilled([
+					{
+						commit: 'd0',
+						serviceName: 'service',
+						contract: {
+							type: 'sw.container',
+							name: 'user-container',
+							slug: 'user-container',
+							// This obvious contract should be valid
+							requires: [{ type: 'hw.device-type' }],
+						},
+						optional: false,
+					},
+				]),
+			)
+				.to.have.property('valid')
+				.that.equals(true);
 		});
 
 		it('should refuse to run containers whose requirements are not satisfied', async () => {


### PR DESCRIPTION
A contract including extra requirement fields, such as "name" would fail validation. This PR removes any extra fields from the validated contract to prevent services with these extra fields from getting rejected by the contract validation.

Change-type: patch