### PR TITLE
Exclude reclaimable slab memory from used memory metric

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "sinon-chai": "^3.7.0",
         "strict-event-emitter-types": "^2.0.0",
         "supertest": "^7.0.0",
-        "systeminformation": "^5.25.11",
+        "systeminformation": "^5.27.0",
         "tar-stream": "^3.1.7",
         "terser-webpack-plugin": "^5.3.11",
         "ts-loader": "^9.5.2",
@@ -13234,11 +13234,10 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.25.11",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.25.11.tgz",
-      "integrity": "sha512-jI01fn/t47rrLTQB0FTlMCC+5dYx8o0RRF+R4BPiUNsvg5OdY0s9DKMFmJGrx5SwMZQ4cag0Gl6v8oycso9b/g==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.0.tgz",
+      "integrity": "sha512-zGORCUwHh9XoDK92HO/2jZT2Kj1sEU1t62iRpk3RDXVs4Af7QE/ot4cZ3I3XO0q6SmOIiZjCGHZM0zzqbUHGcA==",
       "dev": true,
-      "license": "MIT",
       "os": [
         "darwin",
         "linux",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "sinon-chai": "^3.7.0",
     "strict-event-emitter-types": "^2.0.0",
     "supertest": "^7.0.0",
-    "systeminformation": "^5.25.11",
+    "systeminformation": "^5.27.0",
     "tar-stream": "^3.1.7",
     "terser-webpack-plugin": "^5.3.11",
     "ts-loader": "^9.5.2",

--- a/src/lib/system-info.ts
+++ b/src/lib/system-info.ts
@@ -56,9 +56,10 @@ export async function getMemoryInformation(): Promise<{
 	used: number;
 	total: number;
 }> {
+	// Used memory aligned with htop and Busybox's free; see Issue 2419
 	const mem = await systeminformation.mem();
 	return {
-		used: bytesToMb(mem.used - mem.cached - mem.buffers),
+		used: bytesToMb(mem.used - mem.cached - mem.buffers - mem.reclaimable),
 		total: bytesToMb(mem.total),
 	};
 }

--- a/test/unit/lib/system-info.spec.ts
+++ b/test/unit/lib/system-info.spec.ts
@@ -157,7 +157,7 @@ describe('System information', () => {
 				used: sysInfo.bytesToMb(
 					mockMemory.total -
 						mockMemory.free -
-						(mockMemory.cached + mockMemory.buffers),
+						(mockMemory.cached + mockMemory.buffers + mockMemory.reclaimable),
 				),
 			});
 		});
@@ -457,6 +457,7 @@ const mockMemory = {
 	cached: 1055621120,
 	slab: 252219392,
 	buffcache: 1494110208,
+	reclaimable: 57151488,
 	swaptotal: 2016358400,
 	swapused: 0,
 	swapfree: 2016358400,


### PR DESCRIPTION
# Description
A customer report showed that the used memory metric may be overstated significantly. See the issue below for details. This update also aligns the reported value for used memory with the value reported by _free_ and _htop_, which provides a simple way to validate readings in the dashboard.

Fixes #2419 

# Type of change
patch

# How Has This Been Tested?
Updated unit test. Also used a live device to compare value in dashboard to used value from _free_.
