### PR TITLE
Allow overriding apiEndpoint from a database field

### DIFF
--- a/src/config/functions.ts
+++ b/src/config/functions.ts
@@ -11,6 +11,26 @@ import * as hostUtils from '../lib/host-utils';
 import log from '../lib/supervisor-console';
 
 export const fnSchema = {
+	apiEndpointHost: memoizee(
+		async () => {
+			const data = await hostUtils.readFromBoot(
+				hostUtils.pathOnBoot('config.json'),
+				'utf-8',
+			);
+
+			const configJson = JSON.parse(data);
+			return configJson.apiEndpoint;
+		},
+		{ promise: true },
+	),
+	apiEndpoint: async () => {
+		const { apiEndpointOverride, apiEndpointHost } = await config.getMany([
+			'apiEndpointOverride',
+			'apiEndpointHost',
+		]);
+
+		return apiEndpointOverride ?? apiEndpointHost;
+	},
 	version: () => {
 		return Promise.resolve(supervisorVersion);
 	},

--- a/src/config/schema-type.ts
+++ b/src/config/schema-type.ts
@@ -12,6 +12,14 @@ export const schemaTypes = {
 		type: t.string,
 		default: '',
 	},
+	apiEndpointHost: {
+		type: t.string,
+		default: NullOrUndefined,
+	},
+	apiEndpointOverride: {
+		type: t.string,
+		default: NullOrUndefined,
+	},
 	/**
 	 * The timeout for the supervisor's api
 	 */
@@ -22,6 +30,10 @@ export const schemaTypes = {
 	listenPort: {
 		type: PermissiveNumber,
 		default: 48484,
+	},
+	listenPortOverride: {
+		type: PermissiveNumber,
+		default: NullOrUndefined,
 	},
 	deltaEndpoint: {
 		type: t.string,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,6 +1,6 @@
 export const schema = {
-	apiEndpoint: {
-		source: 'config.json',
+	apiEndpointOverride: {
+		source: 'db',
 		mutable: false,
 		removeIfNull: false,
 	},
@@ -13,10 +13,16 @@ export const schema = {
 		removeIfNull: false,
 	},
 	listenPort: {
-		source: 'config.json',
+		source: 'db',
 		mutable: false,
 		removeIfNull: false,
 	},
+	listenPortOverride: {
+		source: 'db',
+		mutable: false,
+		removeIfNull: false,
+	},
+
 	deltaEndpoint: {
 		source: 'config.json',
 		mutable: false,

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -19,6 +19,7 @@ import * as firewall from './lib/firewall';
 const startupConfigFields: config.ConfigKey[] = [
 	'uuid',
 	'listenPort',
+	'listenPortOverride',
 	'apiEndpoint',
 	'apiTimeout',
 	'unmanaged',
@@ -64,6 +65,9 @@ export class Supervisor {
 			await normaliseLegacyDatabase();
 		}
 
+		// Listen on the override port if set
+		const listenPort = conf.listenPortOverride ?? conf.listenPort;
+
 		// Start the state engine, the device API and API binder in parallel
 		await Promise.all([
 			deviceState.loadInitialState(),
@@ -74,7 +78,7 @@ export class Supervisor {
 					healthchecks: [apiBinder.healthcheck, deviceState.healthcheck],
 				});
 				deviceState.on('shutdown', () => this.api.stop());
-				return this.api.listen(conf.listenPort, conf.apiTimeout);
+				return this.api.listen(listenPort, conf.apiTimeout);
 			})(),
 			apiBinder.start(),
 		]);

--- a/test/integration/config/configJson.spec.ts
+++ b/test/integration/config/configJson.spec.ts
@@ -55,7 +55,6 @@ describe('ConfigJsonConfigBackend', () => {
 			'/mnt/root/etc/os-release': testfs.from('test/data/etc/os-release'),
 		}).enable();
 
-		expect(await configJsonConfigBackend.get('apiEndpoint')).to.equal('foo');
 		expect(await configJsonConfigBackend.get('deviceId')).to.equal(123);
 		expect(await configJsonConfigBackend.get('persistentLogging')).to.equal(
 			true,
@@ -93,12 +92,10 @@ describe('ConfigJsonConfigBackend', () => {
 		}).enable();
 
 		await configJsonConfigBackend.set({
-			apiEndpoint: 'bar',
 			deviceId: 456,
 			persistentLogging: false,
 		});
 
-		expect(await configJsonConfigBackend.get('apiEndpoint')).to.equal('bar');
 		expect(await configJsonConfigBackend.get('deviceId')).to.equal(456);
 		expect(await configJsonConfigBackend.get('persistentLogging')).to.equal(
 			false,
@@ -153,13 +150,13 @@ describe('ConfigJsonConfigBackend', () => {
 	it('should get cached value even if actual value has changed', async () => {
 		tfs = await testfs({
 			[CONFIG_PATH]: JSON.stringify({
-				apiEndpoint: 'foo',
+				deltaEndpoint: 'foo',
 			}),
 			'/mnt/root/etc/os-release': testfs.from('test/data/etc/os-release'),
 		}).enable();
 
 		// The cached value should be returned
-		expect(await configJsonConfigBackend.get('apiEndpoint')).to.equal('foo');
+		expect(await configJsonConfigBackend.get('deltaEndpoint')).to.equal('foo');
 
 		// Change the value in the file
 		await fs.writeFile(
@@ -170,34 +167,34 @@ describe('ConfigJsonConfigBackend', () => {
 		);
 
 		// Unintended behavior: the cached value should not be overwritten
-		expect(await configJsonConfigBackend.get('apiEndpoint')).to.equal('foo');
+		expect(await configJsonConfigBackend.get('deltaEndpoint')).to.equal('foo');
 	});
 
 	it('should set value and refresh cache to equal new value', async () => {
 		tfs = await testfs({
 			[CONFIG_PATH]: JSON.stringify({
-				apiEndpoint: 'foo',
+				deltaEndpoint: 'foo',
 			}),
 			'/mnt/root/etc/os-release': testfs.from('test/data/etc/os-release'),
 		}).enable();
 
-		expect(await configJsonConfigBackend.get('apiEndpoint')).to.equal('foo');
+		expect(await configJsonConfigBackend.get('deltaEndpoint')).to.equal('foo');
 
 		await fs.writeFile(
 			CONFIG_PATH,
 			JSON.stringify({
-				apiEndpoint: 'bar',
+				deltaEndpoint: 'bar',
 			}),
 		);
 
 		// Unintended behavior: cached value should not have been updated
 		// as the change was not written to config.json by the Supervisor
-		expect(await configJsonConfigBackend.get('apiEndpoint')).to.equal('foo');
+		expect(await configJsonConfigBackend.get('deltaEndpoint')).to.equal('foo');
 
 		await configJsonConfigBackend.set({
-			apiEndpoint: 'baz',
+			deltaEndpoint: 'baz',
 		});
 
-		expect(await configJsonConfigBackend.get('apiEndpoint')).to.equal('baz');
+		expect(await configJsonConfigBackend.get('deltaEndpoint')).to.equal('baz');
 	});
 });


### PR DESCRIPTION
This is an experimental change to allow an external service to intercept API calls of the supervisor as a potential path for migration

Change-type: patch