### PR TITLE
Save local image in database on every change

### DIFF
--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -777,10 +777,16 @@ function saveAndRemoveImages(
 				return false;
 			});
 
-			// There is no image in the database with the same metadata
-			const isNotSaved = !availableWithoutIds.some((img) =>
-				_.isEqual(img, targetImage),
-			);
+			const isNotSaved =
+				// There is no image in the database with the same metadata
+				!availableWithoutIds.some((img) => _.isEqual(img, targetImage)) ||
+				// Or if there is an image then the docker ids match
+				(targetImageDockerIds[targetImage.name] != null &&
+					!availableImages.some(
+						(img) =>
+							img.name === targetImage.name &&
+							img.dockerImageId === targetImageDockerIds[targetImage.name],
+					));
 
 			// The image is not on the database but we know it exists on the
 			// engine because we could find it through inspectByName

--- a/src/compose/images.ts
+++ b/src/compose/images.ts
@@ -731,12 +731,13 @@ async function removeImageIfNotNeeded(image: Image): Promise<void> {
 
 async function markAsSupervised(image: Image): Promise<void> {
 	const formattedImage = format(image);
+	const { dockerImageId, ...imageWithoutId } = formattedImage;
 	await db.upsertModel(
 		'image',
 		formattedImage,
 		// TODO: Upsert to new values only when they already match? This is likely a bug
 		// and currently acts like an "insert if not exists"
-		formattedImage,
+		imageWithoutId,
 	);
 }
 


### PR DESCRIPTION
The local docker image tag always remains the same, but the image docker id changes on every new push. Before this, the supervisor would revert to the first pushed image.

This is a WIP as it still lacks tests

Change-type: patch
Relates-to: #2367