### PR TITLE
Do not block calls to dbus reboot/shutdown

### DIFF
--- a/src/device-state/index.ts
+++ b/src/device-state/index.ts
@@ -474,11 +474,13 @@ export async function shutdown({
 			switch (reboot) {
 				case true:
 					logger.logSystemMessage('Rebooting', {}, 'Reboot');
-					dbusAction = await dbus.reboot();
+					// Trigger the dbus operation and return immediately to allow the caller to
+					// cleanup before shutdown
+					dbusAction = void dbus.reboot();
 					break;
 				case false:
 					logger.logSystemMessage('Shutting down', {}, 'Shutdown');
-					dbusAction = await dbus.shutdown();
+					dbusAction = void dbus.shutdown();
 					break;
 			}
 			shuttingDown = true;


### PR DESCRIPTION
This should give the supervisor API time to respond to queries before the device goes down.

Change-type: patch