### PR TITLE
Add support for async OS updates

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -20,7 +20,7 @@ services:
       - mock-systemd
     volumes:
       - dbus:/shared/dbus
-      - tmp:/mnt/root/tmp/balena-supervisor/services
+      - services:/mnt/root/tmp/balena-supervisor/services
       - ./test/data/root:/mnt/root
       - ./test/data/root/mnt/boot:/mnt/boot
       - ./test/lib/wait-for-it.sh:/wait-for-it.sh
@@ -78,7 +78,7 @@ services:
     stop_grace_period: 3s
     volumes:
       - dbus:/shared/dbus
-      - tmp:/mnt/root/tmp/balena-supervisor/services
+      - services:/mnt/root/tmp/balena-supervisor/services
     # Set required supervisor configuration variables here
     environment:
       DOCKER_HOST: tcp://docker:2375
@@ -110,7 +110,7 @@ volumes:
     driver_opts:
       type: tmpfs
       device: tmpfs
-  tmp:
+  services:
     driver_opts:
       type: tmpfs
       device: tmpfs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 version: '2.3'
 
+x-helios-image: &helios-image
+  image: ghcr.io/balena-io/helios:0.25.4
+
 services:
   # This service can only be named `main` or `balena-supervisor` as older
   # devices will keep relying on the `/v6/supervisor_release` endpoint that
@@ -14,3 +17,66 @@ services:
       io.balena.features.balena-api: '1'
       io.balena.features.dbus: '1'
       io.balena.features.balena-socket: '1'
+
+  # This is the next generation supervisor service. When started, it becomes a proxy
+  # for calls between the existing supervisor and the balenaAPI and containers
+  helios:
+    <<: *helios-image
+    restart: on-failure
+    labels:
+      # Needed to get access to supervisor api variables
+      # and credentials
+      io.balena.features.supervisor-api: '1'
+      # Needed for access to DOCKER_HOST
+      io.balena.features.balena-socket: '1'
+      # Needed to stop the supervisor service
+      io.balena.features.dbus: '1'
+      # Needed to get access to the API credentials
+      io.balena.features.balena-api: '1'
+      # Needed to get Host OS metadata
+      io.balena.features.host-os.board-rev: '1'
+    environment:
+      - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
+      # Needed for locks and balenahup. This needs to match the device
+      # used for the `runtime` volume
+      - BALENA_HOST_RUNTIME_DIR=/tmp/balena-supervisor
+    volumes:
+      # Critical configurations
+      - config:/config/helios
+      # Request caching
+      - cache:/cache/helios
+      # Persistent system state data that can be reconstructed from
+      # the target state
+      - state:/local/helios
+      # Runtime directory. Data here does not persist after reboots
+      - runtime:/tmp/run
+
+  # The service below exposes the port on the network
+  # On balenaOS devices, this will probably be done by the OS and the
+  # access controlled via the firewall
+  helios-api:
+    <<: *helios-image
+    command: socat TCP-LISTEN:48484,reuseaddr,fork UNIX-CONNECT:/tmp/run/helios.sock
+    ports:
+      - 48484
+    depends_on:
+      - helios
+    volumes:
+      - runtime:/tmp/run
+    healthcheck:
+      test: ['CMD', 'wget', '-O', '-', '-q', 'http://127.0.0.1:48484/ping']
+
+volumes:
+  config:
+  state:
+    labels:
+      # the database version, can be bumped to re-create the state
+      io.balena.private.db-version: 0
+  cache:
+  runtime:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      # XXX: this directory needs to exist on the host before the container is started
+      device: /tmp/balena-supervisor

--- a/src/api-binder/poll.ts
+++ b/src/api-binder/poll.ts
@@ -112,13 +112,19 @@ export const update = async (
 	await config.initialized();
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- it's used for resource management..
 	using _lock = await lockGetTarget();
-	const { uuid, apiEndpoint, apiRequestTimeout, deviceApiKey } =
-		await config.getMany([
-			'uuid',
-			'apiEndpoint',
-			'apiRequestTimeout',
-			'deviceApiKey',
-		]);
+	const {
+		uuid,
+		apiEndpoint,
+		apiEndpointOverride,
+		apiRequestTimeout,
+		deviceApiKey,
+	} = await config.getMany([
+		'uuid',
+		'apiEndpoint',
+		'apiEndpointOverride',
+		'apiRequestTimeout',
+		'deviceApiKey',
+	]);
 
 	if (typeof apiEndpoint !== 'string') {
 		throw new InternalInconsistencyError(
@@ -126,7 +132,10 @@ export const update = async (
 		);
 	}
 
-	const endpoint = url.resolve(apiEndpoint, `/device/v3/${uuid}/state`);
+	const endpoint = url.resolve(
+		apiEndpointOverride ?? apiEndpoint,
+		`/device/v3/${uuid}/state`,
+	);
 	const got = await getGotInstance();
 
 	const { statusCode, headers, body } = await got(endpoint, {

--- a/src/api-binder/report.ts
+++ b/src/api-binder/report.ts
@@ -34,6 +34,7 @@ type StateReportOpts = {
 	[key in keyof Pick<
 		config.ConfigMap<SchemaTypeKey>,
 		| 'apiEndpoint'
+		| 'apiEndpointOverride'
 		| 'apiRequestTimeout'
 		| 'deviceApiKey'
 		| 'appUpdatePollInterval'
@@ -43,7 +44,8 @@ type StateReportOpts = {
 type StateReport = { body: Partial<DeviceState>; opts: StateReportOpts };
 
 async function report({ body, opts }: StateReport) {
-	const { apiEndpoint, apiRequestTimeout, deviceApiKey } = opts;
+	const { apiEndpoint, apiEndpointOverride, apiRequestTimeout, deviceApiKey } =
+		opts;
 
 	if (!apiEndpoint) {
 		throw new InternalInconsistencyError(
@@ -51,7 +53,10 @@ async function report({ body, opts }: StateReport) {
 		);
 	}
 
-	const endpoint = url.resolve(apiEndpoint, `/device/v3/state`);
+	const endpoint = url.resolve(
+		apiEndpointOverride ?? apiEndpoint,
+		`/device/v3/state`,
+	);
 	const request = await getRequestInstance();
 
 	const params: CoreOptions = {
@@ -179,6 +184,7 @@ export async function startReporting() {
 	// Get configs needed to make a report
 	const reportConfigs = (await config.getMany([
 		'apiEndpoint',
+		'apiEndpointOverride',
 		'apiRequestTimeout',
 		'deviceApiKey',
 		'appUpdatePollInterval',

--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -413,6 +413,7 @@ export async function addFeaturesFromLabels(
 			const osBoardRev = await getOSBoardRev(constants.hostOSVersionPath);
 			if (osBoardRev) {
 				setEnvVariables('HOST_OS_BOARD_REV', osBoardRev);
+				setEnvVariables('HOST_OS_BUILD', osBoardRev);
 			}
 		},
 		'io.balena.features.extra-firmware': () => {

--- a/src/config/schema-type.ts
+++ b/src/config/schema-type.ts
@@ -12,6 +12,10 @@ export const schemaTypes = {
 		type: t.string,
 		default: '',
 	},
+	apiEndpointOverride: {
+		type: t.string,
+		default: NullOrUndefined,
+	},
 	/**
 	 * The timeout for the supervisor's api
 	 */
@@ -22,6 +26,10 @@ export const schemaTypes = {
 	listenPort: {
 		type: PermissiveNumber,
 		default: 48484,
+	},
+	listenPortOverride: {
+		type: PermissiveNumber,
+		default: NullOrUndefined,
 	},
 	deltaEndpoint: {
 		type: t.string,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -4,6 +4,11 @@ export const schema = {
 		mutable: false,
 		removeIfNull: false,
 	},
+	apiEndpointOverride: {
+		source: 'db',
+		mutable: false,
+		removeIfNull: false,
+	},
 	/**
 	 * The timeout for the supervisor's api
 	 */
@@ -17,6 +22,12 @@ export const schema = {
 		mutable: false,
 		removeIfNull: false,
 	},
+	listenPortOverride: {
+		source: 'db',
+		mutable: false,
+		removeIfNull: false,
+	},
+
 	deltaEndpoint: {
 		source: 'config.json',
 		mutable: false,

--- a/src/device-api/index.ts
+++ b/src/device-api/index.ts
@@ -72,15 +72,24 @@ export class SupervisorAPI {
 		this.api.use(middleware.errors);
 	}
 
-	public async listen(port: number, apiTimeout: number): Promise<void> {
+	public async listen(
+		port: number,
+		apiTimeout: number,
+		addr?: string,
+	): Promise<void> {
 		return new Promise((resolve) => {
-			this.server = this.api.listen(port, () => {
+			const callback = () => {
 				log.info(`Supervisor API successfully started on port ${port}`);
 				if (this.server) {
 					this.server.timeout = apiTimeout;
 				}
 				resolve();
-			});
+			};
+			if (addr != null) {
+				this.server = this.api.listen(port, addr, callback);
+			} else {
+				this.server = this.api.listen(port, callback);
+			}
 		});
 	}
 

--- a/src/lib/api-helper.ts
+++ b/src/lib/api-helper.ts
@@ -24,12 +24,14 @@ export const getBalenaApi = memoizee(
 	async () => {
 		await config.initialized();
 
-		const { apiEndpoint, currentApiKey } = await config.getMany([
-			'apiEndpoint',
-			'currentApiKey',
-		]);
+		const { apiEndpoint, apiEndpointOverride, currentApiKey } =
+			await config.getMany([
+				'apiEndpoint',
+				'apiEndpointOverride',
+				'currentApiKey',
+			]);
 
-		const baseUrl = url.resolve(apiEndpoint, '/v7/');
+		const baseUrl = url.resolve(apiEndpointOverride ?? apiEndpoint, '/v7/');
 		const passthrough = structuredClone(await request.getRequestOptions());
 		passthrough.headers = passthrough.headers ?? {};
 		passthrough.headers.Authorization = `Bearer ${currentApiKey}`;

--- a/src/lib/firewall.ts
+++ b/src/lib/firewall.ts
@@ -21,6 +21,7 @@ export const initialised = _.once(async () => {
 });
 
 const BALENA_FIREWALL_CHAIN = 'BALENA-FIREWALL';
+const BALENA_SUPERVISOR_CHAIN = 'BALENA-SUPERVISOR';
 
 const prepareChain: iptables.Rule[] = [
 	{
@@ -90,21 +91,40 @@ function updateSupervisorAccessRules(
 	localMode: boolean,
 	interfaces: string[],
 	port: number,
+	overridePort?: number | null,
 ) {
 	supervisorAccessRules = [];
 
-	// if localMode then add a dummy interface placeholder, otherwise add each interface...
-	const matchesIntf = localMode
-		? [[]]
-		: interfaces.map((intf) => [`-i ${intf}`]);
-	for (const intf of matchesIntf) {
+	// if there is an override port set, then just allow traffic on the supervisor0
+	// interface to the override port
+	if (overridePort != null) {
+		// Allow traffic on the override port on the supervisor0 interface
 		supervisorAccessRules.push({
 			comment: 'Supervisor API',
 			action: iptables.RuleAction.Append,
 			proto: 'tcp',
-			matches: [`--dport ${port}`, ...intf],
+			matches: [
+				`--dport ${overridePort}`,
+				`-i ${constants.supervisorNetworkInterface}`,
+			],
 			target: 'ACCEPT',
 		});
+
+		// otherwise configure traffic to the supervisor API port
+	} else {
+		// if localMode then add a dummy interface placeholder, otherwise add each interface...
+		const matchesIntf = localMode
+			? [[]]
+			: interfaces.map((intf) => [`-i ${intf}`]);
+		for (const intf of matchesIntf) {
+			supervisorAccessRules.push({
+				comment: 'Supervisor API',
+				action: iptables.RuleAction.Append,
+				proto: 'tcp',
+				matches: [`--dport ${port}`, ...intf],
+				target: 'ACCEPT',
+			});
+		}
 	}
 
 	// now block access to the port for any interface, since the above should have allowed legitimate traffic...
@@ -112,9 +132,43 @@ function updateSupervisorAccessRules(
 		comment: 'Supervisor API',
 		action: iptables.RuleAction.Append,
 		proto: 'tcp',
-		matches: [`--dport ${port}`],
+		matches: [`--dport ${overridePort ?? port}`],
 		target: 'REJECT',
 	});
+}
+
+let supervisorOverrideAccessRules: iptables.Rule[] = [];
+function updateSupervisorOverrideAccessRules(
+	localMode: boolean,
+	port: number,
+	overridePort?: number | null,
+) {
+	supervisorOverrideAccessRules = [];
+
+	// if the override port is set, we assume the regular API port
+	// is controlled by the docker firewall, so we just need to add a
+	// couple of rules for backwards compatibility. This means
+	// allowing traffic only for the resin-vpn interface when in non local-mode
+	if (overridePort != null && !localMode) {
+		supervisorOverrideAccessRules.push({
+			comment: 'Supervisor API override',
+			action: iptables.RuleAction.Append,
+			proto: 'tcp',
+			matches: [`--dport ${port}`, `-i resin-vpn`],
+			target: 'ACCEPT',
+			family: 4,
+		});
+
+		// block access to the port for anything else
+		supervisorOverrideAccessRules.push({
+			comment: 'Supervisor API override',
+			action: iptables.RuleAction.Append,
+			proto: 'tcp',
+			matches: [`--dport ${port}`],
+			target: 'REJECT',
+			family: 4,
+		});
+	}
 }
 
 async function runningHostBoundServices(): Promise<boolean> {
@@ -131,12 +185,13 @@ async function applyFirewall(
 	// grab the current config...
 	const currentConfig = await config.getMany([
 		'listenPort',
+		'listenPortOverride',
 		'firewallMode',
 		'localMode',
 	]);
 
 	// populate missing config elements...
-	const { listenPort, firewallMode, localMode } = {
+	const { listenPort, listenPortOverride, firewallMode, localMode } = {
 		...opts,
 		...currentConfig,
 	};
@@ -146,6 +201,14 @@ async function applyFirewall(
 		localMode,
 		constants.allowedInterfaces,
 		listenPort,
+		listenPortOverride,
+	);
+
+	// update the Supervisor API override rules
+	updateSupervisorOverrideAccessRules(
+		localMode,
+		listenPort,
+		listenPortOverride,
 	);
 
 	// apply the firewall rules...
@@ -180,16 +243,24 @@ export const applyFirewallMode = async function applyFirewallMode(
 				: [];
 
 		// Get position of BALENA-FIREWALL rule in the INPUT chain for both iptables & ip6tables
-		const v4Position = await iptables.getRulePosition(
+		const balenaFirewallPositionV4 = await iptables.getRulePosition(
 			'INPUT',
-			'BALENA-FIREWALL',
+			BALENA_FIREWALL_CHAIN,
 			4,
 		);
-		const v6Position = await iptables.getRulePosition(
+		const balenaFirewallPositionV6 = await iptables.getRulePosition(
 			'INPUT',
-			'BALENA-FIREWALL',
+			BALENA_FIREWALL_CHAIN,
 			6,
 		);
+
+		// Get position of BALENA-SUPERVISOR rule in the DOCKER-USER chain
+		const balenaSupervisorChainIsSet =
+			(await iptables.getRulePosition(
+				'DOCKER-USER',
+				BALENA_SUPERVISOR_CHAIN,
+				4,
+			)) > 0;
 
 		// get an adaptor to manipulate iptables rules...
 		const ruleAdaptor = iptables.getDefaultRuleAdaptor();
@@ -201,31 +272,31 @@ export const applyFirewallMode = async function applyFirewallMode(
 				filter
 					.forChain('INPUT', (chain) => {
 						// Delete & insert to v4 tables
-						if (v4Position !== -1) {
+						if (balenaFirewallPositionV4 !== -1) {
 							chain.addRule({
 								action: iptables.RuleAction.Delete,
-								target: 'BALENA-FIREWALL',
+								target: BALENA_FIREWALL_CHAIN,
 								family: 4,
 							});
 						}
 						chain.addRule({
 							action: iptables.RuleAction.Insert,
-							id: v4Position > 0 ? v4Position : 1,
-							target: 'BALENA-FIREWALL',
+							id: balenaFirewallPositionV4 > 0 ? balenaFirewallPositionV4 : 1,
+							target: BALENA_FIREWALL_CHAIN,
 							family: 4,
 						});
 						// Delete & insert to v6 tables
-						if (v6Position !== -1) {
+						if (balenaFirewallPositionV6 !== -1) {
 							chain.addRule({
 								action: iptables.RuleAction.Delete,
-								target: 'BALENA-FIREWALL',
+								target: BALENA_FIREWALL_CHAIN,
 								family: 6,
 							});
 						}
 						chain.addRule({
 							action: iptables.RuleAction.Insert,
-							id: v6Position > 0 ? v6Position : 1,
-							target: 'BALENA-FIREWALL',
+							id: balenaFirewallPositionV6 > 0 ? balenaFirewallPositionV6 : 1,
+							target: BALENA_FIREWALL_CHAIN,
 							family: 6,
 						});
 						return chain;
@@ -242,6 +313,21 @@ export const applyFirewallMode = async function applyFirewallMode(
 								action: iptables.RuleAction.Append,
 								target: 'REJECT',
 							}),
+					)
+					.forChain('DOCKER-USER', (chain) => {
+						// Add the supervisor chain if not added
+						if (!balenaSupervisorChainIsSet) {
+							chain.addRule({
+								action: iptables.RuleAction.Append,
+								target: BALENA_SUPERVISOR_CHAIN,
+								family: 4,
+							});
+						}
+
+						return chain;
+					})
+					.forChain(BALENA_SUPERVISOR_CHAIN, (chain) =>
+						chain.addRule(prepareChain).addRule(supervisorOverrideAccessRules),
 					),
 			)
 			.apply(ruleAdaptor);

--- a/src/lib/iptables.ts
+++ b/src/lib/iptables.ts
@@ -209,7 +209,7 @@ const iptablesRestoreAdaptor: RuleAdaptor = async (
 				if (code && code !== 0) {
 					reject(
 						new IPTablesRuleError(
-							`Error running iptables: ${stderr.join()} (${args.join(' ')})`,
+							`Error running iptables (${family}): ${stderr.join()} (${args.join(' ')})`,
 							ruleset,
 						),
 					);

--- a/src/lib/os-release.ts
+++ b/src/lib/os-release.ts
@@ -71,8 +71,11 @@ export function getOSSemver(path: string): Promise<string | undefined> {
 	return getOSReleaseField(path, 'VERSION');
 }
 
-export function getOSBoardRev(path: string): Promise<string | undefined> {
-	return getOSReleaseField(path, 'BALENA_BOARD_REV');
+export async function getOSBoardRev(path: string): Promise<string | undefined> {
+	return (
+		(await getOSReleaseField(path, 'BALENA_BOARD_REV')) ??
+		(await getOSReleaseField(path, 'RESIN_BOARD_REV'))
+	);
 }
 
 export async function getMetaOSRelease(

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -80,6 +80,9 @@ export class Supervisor {
 
 		// Listen on the override port if set
 		const listenPort = conf.listenPortOverride ?? conf.listenPort;
+		const listenAddr = conf.listenPortOverride
+			? constants.supervisorNetworkGateway
+			: undefined;
 
 		// Start the state engine, the device API and API binder in parallel
 		await Promise.all([
@@ -91,7 +94,7 @@ export class Supervisor {
 					healthchecks: [apiBinder.healthcheck, deviceState.healthcheck],
 				});
 				deviceState.on('shutdown', () => this.api.stop());
-				return this.api.listen(listenPort, conf.apiTimeout);
+				return this.api.listen(listenPort, conf.apiTimeout, listenAddr);
 			})(),
 			apiBinder.start(),
 		]);

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -22,6 +22,7 @@ import * as uname from './lib/uname';
 const startupConfigFields: config.ConfigKey[] = [
 	'uuid',
 	'listenPort',
+	'listenPortOverride',
 	'apiEndpoint',
 	'apiTimeout',
 	'unmanaged',
@@ -77,6 +78,9 @@ export class Supervisor {
 			await normaliseLegacyDatabase();
 		}
 
+		// Listen on the override port if set
+		const listenPort = conf.listenPortOverride ?? conf.listenPort;
+
 		// Start the state engine, the device API and API binder in parallel
 		await Promise.all([
 			deviceState.loadInitialState(),
@@ -87,7 +91,7 @@ export class Supervisor {
 					healthchecks: [apiBinder.healthcheck, deviceState.healthcheck],
 				});
 				deviceState.on('shutdown', () => this.api.stop());
-				return this.api.listen(conf.listenPort, conf.apiTimeout);
+				return this.api.listen(listenPort, conf.apiTimeout);
 			})(),
 			apiBinder.start(),
 		]);


### PR DESCRIPTION
This adds a new service to the supervisor composition. This new service `helios`, proxies communications between this supervisor, the API and app containers.  The new service will little by little take over features of this supervisor until we can drop it entirely. 

The new service is written in Rust for better memory safety and lower resource usage. It will also feature a new planning engine based on [mahler](https://github.com/balena-io-modules/mahler-rs), which removes the need for hard-coding workflows (no more application manager and infer next steps), but can automatically derive a plan from the target and task definitions. The new engine also features better logging and is easier to test. 

## Testing the new service

Run the following commands in your hostOS, replacing the correct architecture in the `supervisor_release` variable

```sh
# Set necessary variables
api_key=$(cat /mnt/boot/config.json | jq -r .deviceApiKey)
uuid=$(cat /mnt/boot/config.json | jq -r .uuid)
api_endpoint=$(cat /mnt/boot/config.json | jq -r .apiEndpoint)

# Supervisor releases
amd64_supervisor=4018627
aarch64_supervisor=4018812
armv7_supervisor=4018628
# Make sure to use the right id for your architecture here
supervisor_release="${aarch64_supervisor}"

supervisor_img=$(\
  curl -X GET \
    "$api_endpoint/v7/release($supervisor_release)?\$expand=contains__image(\$expand=image(\$select=is_stored_at__image_location))" \
    -H  "Content-Type: application/json" \
    -H "Authorization: Bearer $api_key" | jq -r .d[0].contains__image[0].image[0].is_stored_at__image_location \
)

# Patch the device to the draft release
curl -X PATCH -H "Authorization: Bearer $api_key" -H  "Content-Type: application/json" "$api_endpoint/v6/device?\$filter=uuid%20eq%20'$uuid'" -d "{\"should_be_managed_by__supervisor_release\": $supervisor_release}"

# Update the supervisor to the target image
update-balena-supervisor -i "$supervisor_img"
```

Change-type: major

## Release Notes

This release is the first step to migrating the supervisor to a new codebase. It introduces a new service `helios` that acts as a proxy between the existing `balena-supervisor` container, the balena API and other containers. This service will slowly take the supervisor responsibilities until the old service can be replaced entirely. 

The new service is written in Rust for better memory safety and lower resource usage (should use around 5mb of memory). It is just a regular container, and doesn't require any special host privileges or host networking access. To get around the need for special permissions, a second container `helios-api` is included with this release. That service is just a relay of requests to a Unix domain socket where the main service listens for requests.

The new service also provides a long requested feature for the on-device agent service. The ability to perform OS updates without the need of Cloudlink access (async OS updates). Devices can now be pinned to a new target OS release and the agent will receive the new OS release through the target state on the next poll and install the new release as it would do with any other app and wait until locks are cleared in order to boot to the new OS. The service keeps track of failed attempts to abort the process after a certain number of tries. 