### PR TITLE
config/backends/power-fan: Enable configurable power and fan for Fore…

### DIFF
--- a/src/config/backends/power-fan.ts
+++ b/src/config/backends/power-fan.ts
@@ -62,6 +62,7 @@ export class PowerFanConfig extends ConfigBackend {
 			'jetson-orin-nano-seeed-j3010',
 			'jetson-orin-nx-seeed-j4012',
 			'jetson-orin-nx-xavier-nx-devkit',
+			'forecr-dsb-ornx-orin-nano-8gb',
 		]).has(deviceType);
 	}
 

--- a/test/integration/config/power-fan.spec.ts
+++ b/test/integration/config/power-fan.spec.ts
@@ -22,6 +22,7 @@ const SUPPORTED_DEVICE_TYPES = [
 	'jetson-orin-nano-seeed-j3010',
 	'jetson-orin-nx-seeed-j4012',
 	'jetson-orin-nx-xavier-nx-devkit',
+	'forecr-dsb-ornx-orin-nano-8gb',
 ];
 
 const UNSUPPORTED_DEVICE_TYPES = ['jetson-orin-nx-xv3'];


### PR DESCRIPTION
config/backends/power-fan: Enable configurable power and fan for Forecr DSBOARD ORNX Nano 8GB

Change-type: patch

This change allows power modes and configurable fan modes to be applied to the Forecr DSB ORNX Nano 8GB

Connects-to: https://github.com/balena-io/open-balena-api/pull/2061