### PR TITLE
Only publish + finalize arm64 & amd64 for staging

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -28,12 +28,6 @@ jobs:
         balena_os/i386-supervisor,
         balena_os/rpi-supervisor
       custom_publish_matrix: balena_os/aarch64-supervisor,
-        balena_os/amd64-supervisor,
-        balena_os/armv7hf-supervisor,
-        balena_os/i386-supervisor,
-        balena_os/rpi-supervisor
+        balena_os/amd64-supervisor
       custom_finalize_matrix: balena_os/aarch64-supervisor,
-        balena_os/amd64-supervisor,
-        balena_os/armv7hf-supervisor,
-        balena_os/i386-supervisor,
-        balena_os/rpi-supervisor
+        balena_os/amd64-supervisor


### PR DESCRIPTION
The armv7/v6 builds are broken due to emulating on QEMU with Alpine musl, and tests are run on arm/amd64 anyway.

Change-type: patch
Caused-by: https://balena.fibery.io/Work/Project/Redistribute-Hetzner-builder-workers-1939