### PR TITLE
Add runtime and annotations support for co-processor firmware

### DIFF
--- a/src/compose/sanitise.ts
+++ b/src/compose/sanitise.ts
@@ -57,6 +57,8 @@ const supportedComposeFields = [
 	'user',
 	'workingDir',
 	'tty',
+	'runtime',
+	'annotations',
 ];
 
 export function sanitiseComposeConfig(

--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -1,6 +1,7 @@
 import { detailedDiff as diff } from 'deep-object-diff';
 import type Dockerode from 'dockerode';
 import Duration from 'duration-js';
+import fs from 'fs';
 import _ from 'lodash';
 import path from 'path';
 
@@ -105,6 +106,26 @@ class ServiceImpl implements Service {
 
 	private constructor() {
 		/* do not allow instancing a service object with `new` */
+	}
+
+	// Auto-detect the first available remoteproc device name by reading
+	// /sys/class/remoteproc/remoteproc{N}/name on the host.
+	private static detectRemoteprocName(): string | null {
+		const rprocBase = '/sys/class/remoteproc';
+		try {
+			const entries = fs.readdirSync(rprocBase).sort();
+			for (const entry of entries) {
+				const namePath = path.join(rprocBase, entry, 'name');
+				try {
+					return fs.readFileSync(namePath, 'utf-8').trim();
+				} catch {
+					continue;
+				}
+			}
+		} catch {
+			// /sys/class/remoteproc doesn't exist on this device
+		}
+		return null;
 	}
 
 	// The type here is actually ServiceComposeConfig, except that the
@@ -398,6 +419,11 @@ class ServiceImpl implements Service {
 		// Normalise the config before passing it to defaults
 		ComposeUtils.normalizeNullValues(config);
 
+		// Normalise annotations from compose (may be object with string values)
+		if (config.annotations != null && typeof config.annotations === 'object') {
+			config.annotations = _.mapValues(config.annotations, String);
+		}
+
 		service.config = _.defaults(config, {
 			portMaps,
 			capAdd: [],
@@ -447,7 +473,24 @@ class ServiceImpl implements Service {
 			workingDir: '',
 			tty: true,
 			running: true,
+			runtime: '',
+			annotations: {},
 		});
+
+		// For remoteproc runtime, auto-detect the remoteproc device name
+		// and inject it into the config so it matches what Docker will report
+		if (
+			service.config.runtime === 'io.containerd.remoteproc.v1' &&
+			!service.config.annotations?.['remoteproc.name']
+		) {
+			const rprocName = Service.detectRemoteprocName();
+			if (rprocName) {
+				service.config.annotations = {
+					...service.config.annotations,
+					'remoteproc.name': rprocName,
+				};
+			}
+		}
 
 		// If we have the docker image ID, we replace the image
 		// with that
@@ -606,6 +649,11 @@ class ServiceImpl implements Service {
 			user: container.Config.User ?? '',
 			workingDir: container.Config.WorkingDir ?? '',
 			tty: container.Config.Tty ?? false,
+			runtime:
+				((container.HostConfig as any).Runtime === 'runc'
+					? ''
+					: (container.HostConfig as any).Runtime) ?? '',
+			annotations: (container.HostConfig as any).Annotations ?? {},
 		};
 
 		// Only add `init` if true or false, otherwise leave blank
@@ -684,7 +732,7 @@ class ServiceImpl implements Service {
 			}
 			this.config.networkMode = `container:${containerId}`;
 		}
-		return {
+		const createOpts: Dockerode.ContainerCreateOptions = {
 			name: `${this.serviceName}_${this.imageId}_${this.releaseId}_${this.commit}`,
 			Tty: this.config.tty,
 			Cmd: this.config.command,
@@ -755,12 +803,21 @@ class ServiceImpl implements Service {
 				NanoCpus: this.config.cpus,
 				IpcMode: this.config.ipc,
 				Init: this.config.init,
+				Runtime: this.config.runtime || undefined,
 			} as Dockerode.ContainerCreateOptions['HostConfig'],
 			Healthcheck: ComposeUtils.serviceHealthcheckToDockerHealthcheck(
 				this.config.healthcheck,
 			),
 			StopTimeout: this.config.stopGracePeriod,
 		};
+
+		// Pass annotations inside HostConfig (balena-engine v27+ placement)
+		// Annotations are auto-injected in fromComposeObject for remoteproc runtime
+		if (!_.isEmpty(this.config.annotations)) {
+			(createOpts.HostConfig as any).Annotations = this.config.annotations;
+		}
+
+		return createOpts;
 	}
 
 	public isEqualConfig(

--- a/src/compose/types/service.ts
+++ b/src/compose/types/service.ts
@@ -219,6 +219,8 @@ export interface ServiceComposeConfig {
 	user?: string;
 	workingDir?: string;
 	tty?: boolean;
+	runtime?: string;
+	annotations?: Record<string, string>;
 }
 
 // This is identical to ServiceComposeConfig, except for the
@@ -284,6 +286,8 @@ export interface ServiceConfig {
 	user: string;
 	workingDir: string;
 	tty: boolean;
+	runtime: string;
+	annotations: Record<string, string>;
 }
 
 export type ServiceConfigArrayField =


### PR DESCRIPTION
⚠️ ⚠️ ⚠️ **DO NOT MERGE, this is just a POC**⚠️ ⚠️ ⚠️ 

Enable the supervisor to manage co-processor firmware containers using custom OCI runtimes (e.g. ARM's remoteproc-runtime). This allows firmware to be deployed as standard OCI images and loaded onto co-processors like the Cortex-M7 via Linux remoteproc.

Changes:
- Add `runtime` and `annotations` to compose service config
- Pass `runtime` through to HostConfig.Runtime on container create
- Pass `annotations` through to HostConfig.Annotations (balena-engine v27+ placement, not top-level)
- Auto-detect remoteproc device name from /sys/class/remoteproc/ and inject `remoteproc.name` annotation when runtime is `io.containerd.remoteproc.v1`
- Normalize runtime "runc" to "" in fromDockerContainer() to prevent false config diffs causing container recreate loops

Change-type: minor

