### PR TITLE
Firewall: avoid `exports.` to improve type-checking

### DIFF
--- a/src/lib/firewall.ts
+++ b/src/lib/firewall.ts
@@ -149,12 +149,14 @@ async function applyFirewall(
 	);
 
 	// apply the firewall rules...
-	await exports.applyFirewallMode(firewallMode ?? '');
+	await applyFirewallMode(firewallMode ?? '');
 }
 
 export const ALLOWED_MODES = ['on', 'off', 'auto'];
 
-export async function applyFirewallMode(mode: string) {
+export const applyFirewallMode = async function applyFirewallMode(
+	mode: string,
+) {
 	// only apply valid mode...
 	if (!ALLOWED_MODES.includes(mode)) {
 		log.warn(`Invalid firewall mode: ${mode}. Reverting to state: off`);
@@ -255,4 +257,4 @@ export async function applyFirewallMode(mode: string) {
 			log.debug(`Ruleset:\r\n${err.ruleset}`);
 		}
 	}
-}
+};


### PR DESCRIPTION
`exports` is `any` so referencing it means no typings are applied in cases you would normally expect them to be and means that it's easy to introduce bugs due to expecting typescript to be able to catch them when in fact it's gone via a commonjs indirection. As an added benefit it also makes the code more ESM ready

Change-type: patch

*If this is a regression, consider adding it to #1898!*

# Description

Please include a summary of the change and which issue was fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Type of change

Include at least one commit in your PR that marks the change-type. This can be either specified through a Change-type footer, or by adding the change-type as a prefix to the commit, i.e. minor: Add some new feature. This is so the PR can be automatically versioned and a changelog generated for it by using versionist. Check out [semver](https://semver.org/) for a detailed explanation of the different possible change-type values.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
