### PR TITLE
Trim whitespaces around dtparam input values

### DIFF
--- a/src/config/backends/config-txt.ts
+++ b/src/config/backends/config-txt.ts
@@ -150,9 +150,9 @@ export class ConfigTxt extends ConfigBackend {
 								// We make sure to put the base param in the right overlays
 								// since RPI doesn't seem to be too strict about the ordering
 								// when it comes to these base params
-								baseParams.push(value);
+								baseParams.push(param);
 							} else {
-								currParams.push(value);
+								currParams.push(param);
 							}
 						}
 					} else if (key === 'dtoverlay') {

--- a/src/config/backends/config-txt.ts
+++ b/src/config/backends/config-txt.ts
@@ -250,10 +250,12 @@ export class ConfigTxt extends ConfigBackend {
 
 	public processConfigVarValue(key: string, value: string): string | string[] {
 		if (isArrayConfig(key)) {
-			if (!value.startsWith('"')) {
-				return [value];
+			// Trim surrounding whitespace from the config var
+			const trimmed = value.trim();
+			if (!trimmed.startsWith('"')) {
+				return [trimmed];
 			} else {
-				return JSON.parse(`[${value}]`);
+				return JSON.parse(`[${trimmed}]`);
 			}
 		}
 		return value;

--- a/test/integration/config/config-txt.spec.ts
+++ b/test/integration/config/config-txt.spec.ts
@@ -178,6 +178,28 @@ describe('config/config-txt', () => {
 		await tfs.restore();
 	});
 
+	it('correctly parses dtparam lines with multiple comma-separated params', async () => {
+		// A user could preload a config.txt with multiple comma-separated params
+		// and we should be able to parse them correctly
+		const tfs = await testfs({
+			[hostUtils.pathOnBoot('config.txt')]: stripIndent`
+	        dtparam=audio=on,i2c_arm=on
+					dtoverlay=ads1015
+					dtparam=cha_cfg=4,chb_cfg=5
+					dtparam=spi=on,chc_cfg=6
+					`,
+		}).enable();
+
+		const configTxt = new ConfigTxt();
+
+		await expect(configTxt.getBootConfig()).to.eventually.deep.equal({
+			dtparam: ['audio=on', 'i2c_arm=on', 'spi=on'],
+			dtoverlay: ['ads1015,cha_cfg=4,chb_cfg=5,chc_cfg=6'],
+		});
+
+		await tfs.restore();
+	});
+
 	it('maintains ordering of dtoverlays and dtparams', async () => {
 		const tfs = await testfs({
 			[hostUtils.pathOnBoot('config.txt')]: stripIndent`

--- a/test/unit/config/config-txt.spec.ts
+++ b/test/unit/config/config-txt.spec.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+
+import { ConfigTxt } from '~/src/config/backends/config-txt';
+
+describe('config/config-txt', () => {
+	const backend = new ConfigTxt();
+
+	describe('processConfigVarValue', () => {
+		it('parses a quoted CSV array value into multiple entries', () => {
+			expect(
+				backend.processConfigVarValue(
+					'dtparam',
+					'"i2c_arm=on","spi=on","audio=off"',
+				),
+			).to.deep.equal(['i2c_arm=on', 'spi=on', 'audio=off']);
+		});
+
+		it('returns an unquoted single value as a one-element array', () => {
+			expect(
+				backend.processConfigVarValue('dtparam', 'i2c_arm=on'),
+			).to.deep.equal(['i2c_arm=on']);
+		});
+
+		it('tolerates leading/trailing whitespace around a quoted CSV array', () => {
+			expect(
+				backend.processConfigVarValue(
+					'dtparam',
+					' "i2c_arm=on","spi=on","audio=off"',
+				),
+			).to.deep.equal(['i2c_arm=on', 'spi=on', 'audio=off']);
+
+			expect(
+				backend.processConfigVarValue(
+					'dtparam',
+					'"i2c_arm=on","spi=on","audio=off"  ',
+				),
+			).to.deep.equal(['i2c_arm=on', 'spi=on', 'audio=off']);
+		});
+
+		it('returns non-array config values unchanged', () => {
+			expect(backend.processConfigVarValue('disable_splash', '1')).to.equal(
+				'1',
+			);
+		});
+	});
+});


### PR DESCRIPTION
Slightly more defensive, and prevents boot config apply loop from surrounding whitespaces such as in
`BALENA_HOST_CONFIG_dtparam=" "foo=1","bar=2""`

Do note that whitespaces are invalid as part of an input, and inputs like these are user error.

Encountered on support where user upgraded from v14.x.x SV to v17.x.x. The behavior change originates from v16.0.0 which adds multiline dtparam handling. Pre-v16 Supervisors handled any whitespaces gracefully.

Change-type: patch