### PR TITLE
Invalidate target state cache when creating device config variables

### DIFF
--- a/src/api-binder/index.ts
+++ b/src/api-binder/index.ts
@@ -358,6 +358,7 @@ async function reportInitialEnv(
 				resource: 'device_config_variable',
 				body: envVar,
 			});
+			await TargetState.invalidate();
 		}
 	}
 

--- a/src/api-binder/poll.ts
+++ b/src/api-binder/poll.ts
@@ -38,7 +38,7 @@ type CachedResponse = {
 	emitted?: boolean;
 };
 
-let cache: CachedResponse;
+let cache: CachedResponse | undefined;
 
 /**
  * appUpdatePollInterval is set when startPoll successfuly queries the config
@@ -85,7 +85,7 @@ const emitTargetState = (
 		return true;
 	}
 	// Return the same emitted value but normalized to be a boolean
-	return !!cache.emitted;
+	return !!cache?.emitted;
 };
 
 /**
@@ -98,6 +98,16 @@ export let lastSuccessfulFetch: ReturnType<typeof process.hrtime> =
 	process.hrtime();
 
 /**
+ * Invalidate the in-memory target state cache
+ */
+export const invalidate = async () => {
+	// prevent an invalidation in the middle of an update
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- it's used for resource management..
+	using _lock = await lockGetTarget();
+	cache = undefined;
+};
+
+/**
  * Attempts to update the target state
  * @param force Emitted with the 'target-state-update' event update as necessary
  * @param isFromApi Emitted with the 'target-state-update' event update as necessary
@@ -108,7 +118,7 @@ export const update = async (
 	force = false,
 	isFromApi = false,
 	cancel = false,
-): Promise<void> => {
+): Promise<TargetState> => {
 	await config.initialized();
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- it's used for resource management..
 	using _lock = await lockGetTarget();
@@ -157,7 +167,7 @@ export const update = async (
 		// There's no change so no need to update the cache
 		// only emit the target state if it hasn't been emitted yet
 		cache.emitted = emitTargetState(cache, force, isFromApi, cancel);
-		return;
+		return cache.body;
 	}
 
 	if (statusCode < 200 || statusCode >= 300) {
@@ -173,6 +183,8 @@ export const update = async (
 	// Emit the target state and update the cache, cancelling any
 	// apply operations that may be in progress
 	cache.emitted = emitTargetState(cache, force, isFromApi, true);
+
+	return cache.body;
 };
 
 const poll = async (skipFirstGet = false, fetchErrors = 0): Promise<void> => {
@@ -219,8 +231,7 @@ const poll = async (skipFirstGet = false, fetchErrors = 0): Promise<void> => {
  * Checks for target state changes and then returns the latest target state
  */
 export const get = async (): Promise<TargetState> => {
-	await update();
-	return structuredClone(cache.body);
+	return await update();
 };
 
 /**


### PR DESCRIPTION
There seems to be an edge condition where the API returns a 304 from the target state endpoint even after creating new device config variables. This can result in the supervisor deleting the local configuration in config.txt leaving the device in a malfunctioning state.

This change adds an `invalidate` function to the target state poll module. This invalidates the in-memory target state cache, forcing the supervisor to request the full target state. We call this function after creating a new device config variable to tell the poll module to expect a new target.

Change-type: patch
