### PR TITLE
Pin back to Node 22

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,8 +1,8 @@
 ARG ARCH=%%BALENA_ARCH%%
 ARG FATRW_VERSION=0.2.21
-ARG NODE="nodejs~=24"
+ARG NODE="nodejs~=22"
 ARG NPM="npm~=11"
-ARG ALPINE_VERSION="3.23"
+ARG ALPINE_VERSION="3.22"
 
 ###################################################
 # Build the supervisor dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@types/memoizee": "^0.4.12",
         "@types/mocha": "^10.0.10",
         "@types/morgan": "^1.9.10",
-        "@types/node": "^24.12.0",
+        "@types/node": "^22.19.19",
         "@types/request": "^2.48.13",
         "@types/rewire": "^2.5.30",
         "@types/rwlock": "^5.0.6",
@@ -111,7 +111,7 @@
         "yargs": "^17.7.2"
       },
       "engines": {
-        "node": "^24",
+        "node": "^22",
         "npm": ">=10"
       }
     },
@@ -2165,19 +2165,19 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/node/node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3860,16 +3860,6 @@
       "engines": {
         "node": ">=20.14.0",
         "npm": ">=10.7.0"
-      }
-    },
-    "node_modules/balena-sdk/node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "node_modules/balena-sdk/node_modules/mime": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "sqlite3": "^5.1.7"
   },
   "engines": {
-    "node": "^24",
+    "node": "^22",
     "npm": ">=10"
   },
   "devDependencies": {
@@ -57,7 +57,7 @@
     "@types/memoizee": "^0.4.12",
     "@types/mocha": "^10.0.10",
     "@types/morgan": "^1.9.10",
-    "@types/node": "^24.12.0",
+    "@types/node": "^22.19.19",
     "@types/request": "^2.48.13",
     "@types/rewire": "^2.5.30",
     "@types/rwlock": "^5.0.6",

--- a/src/config/backends/config-txt.ts
+++ b/src/config/backends/config-txt.ts
@@ -73,7 +73,7 @@ export class ConfigTxt extends ConfigBackend {
 	private static PREFIX = `${constants.hostConfigVarPrefix}CONFIG_`;
 	private static PATH = hostUtils.pathOnBoot('config.txt');
 	private static REGEX = new RegExp(
-		'(?:' + RegExp.escape(ConfigTxt.PREFIX) + ')(.+)',
+		'(?:' + _.escapeRegExp(ConfigTxt.PREFIX) + ')(.+)',
 	);
 	// These keys are not config.txt keys and are managed by the power-fan backend.
 	private static UNSUPPORTED_KEYS = ['power_mode', 'fan_profile'];

--- a/src/config/backends/extlinux.ts
+++ b/src/config/backends/extlinux.ts
@@ -36,7 +36,7 @@ export class Extlinux extends ConfigBackend {
 	);
 
 	public static bootConfigVarRegex = new RegExp(
-		'(?:' + RegExp.escape(Extlinux.bootConfigVarPrefix) + ')(.+)',
+		'(?:' + _.escapeRegExp(Extlinux.bootConfigVarPrefix) + ')(.+)',
 	);
 
 	public matches(deviceType: string, metaRelease: string | undefined): boolean {

--- a/src/config/backends/extra-uEnv.ts
+++ b/src/config/backends/extra-uEnv.ts
@@ -52,7 +52,7 @@ export class ExtraUEnv extends ConfigBackend {
 	};
 
 	public static bootConfigVarRegex = new RegExp(
-		'(?:' + RegExp.escape(ExtraUEnv.bootConfigVarPrefix) + ')(.+)',
+		'(?:' + _.escapeRegExp(ExtraUEnv.bootConfigVarPrefix) + ')(.+)',
 	);
 
 	public async matches(deviceType: string): Promise<boolean> {

--- a/src/config/backends/odmdata.ts
+++ b/src/config/backends/odmdata.ts
@@ -31,7 +31,7 @@ export class Odmdata extends ConfigBackend {
 	private CONFIG_BUFFER = Buffer.from(this.CONFIG_BYTES);
 
 	public static bootConfigVarRegex = new RegExp(
-		'(?:' + RegExp.escape(Odmdata.bootConfigVarPrefix) + ')(.+)',
+		'(?:' + _.escapeRegExp(Odmdata.bootConfigVarPrefix) + ')(.+)',
 	);
 
 	public matches(deviceType: string): boolean {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,7 @@ externalModules.push(
 	new RegExp(
 		'^(' +
 			_.reject(maybeOptionalModules, requiredModules)
-				.map(RegExp.escape)
+				.map(_.escapeRegExp)
 				.join('|') +
 			')(/.*)?$',
 	),
@@ -99,7 +99,7 @@ module.exports = function (env) {
 				{
 					include: [
 						new RegExp(
-							RegExp.escape(
+							_.escapeRegExp(
 								// this is the path as of knex@2.5.1
 								path.join('knex', 'lib', 'migrations', 'common'),
 							),
@@ -109,7 +109,7 @@ module.exports = function (env) {
 				},
 				{
 					test: new RegExp(
-						RegExp.escape(path.join('JSONStream', 'index.js')) + '$',
+						_.escapeRegExp(path.join('JSONStream', 'index.js')) + '$',
 					),
 					use: require.resolve('./build-utils/fix-jsonstream'),
 				},


### PR DESCRIPTION
SV on RPi Zero was working in 17.6.10 but not 17.6.11 which bumped Node to 24. 

Node 24's V8 engine has issues with `rpi`/armv6 arch, throwing `Fatal error in , line 0 unreachable code`.

We still support RPi Zero devices in production, roughly 3k at time of this commit.

Change-type: patch
See: https://balena.fibery.io/Work/Improvement/Unblock-the-raspberrypi-pipeline-4203
