### PR TITLE
tests: Run compose tests against all platforms

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -31,3 +31,22 @@ jobs:
         balena_os/amd64-supervisor
       custom_finalize_matrix: balena_os/aarch64-supervisor,
         balena_os/amd64-supervisor
+      # linux/arm/v6 pinned to x86_64 runners — not for performance, for fidelity.
+      # ARM64 hosts can execute 32-bit ARM binaries natively in AArch32 mode,
+      # which exposes the host's ARMv7+ features (NEON, idiv, advanced atomics)
+      # through HWCAP and /proc/cpuinfo. V8's runtime CPU detection then emits
+      # modern instructions — which work on the host but would trap on real
+      # ARMv6 silicon like the Pi Zero. On x86_64 there's no native 32-bit ARM
+      # execution available, so binfmt_misc routes to QEMU. Combined with
+      # QEMU_CPU=arm1176 in the image, QEMU emulates ARM1176JZF-S faithfully
+      # (no NEON, no idiv), forcing V8 down the same codegen path it would
+      # follow on real Pi Zero hardware. This is how we caught the Node 24
+      # crash that only manifested on production devices.
+      docker_runs_on: >
+        {
+          "linux/amd64": ["ubuntu-24.04"],
+          "linux/arm64": ["ubuntu-24.04-arm"],
+          "linux/arm/v7": ["ubuntu-24.04"],
+          "linux/arm/v6": ["ubuntu-24.04"],
+          "linux/386": ["ubuntu-24.04"]
+        }

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,11 +5,37 @@ ARG NPM="npm~=11"
 ARG ALPINE_VERSION="3.23"
 
 ###################################################
+# Resolve the balena arch.
+# If ARCH is already a known balena arch (set by
+# balena CLI's %%BALENA_ARCH%% substitution or via
+# --build-arg), use it. Otherwise derive from
+# BuildKit's TARGETARCH/TARGETVARIANT — set on
+# docker buildx/bake/compose builds, unset under
+# balena push (which doesn't use BuildKit).
+###################################################
+FROM alpine:${ALPINE_VERSION} AS arch-info
+ARG ARCH
+ARG TARGETARCH
+ARG TARGETVARIANT
+RUN case "${ARCH:-}" in \
+		amd64|aarch64|armv7hf|rpi|i386) ;; \
+		*) \
+			case "${TARGETARCH:-}${TARGETVARIANT:+/${TARGETVARIANT}}" in \
+				amd64)  ARCH=amd64 ;; \
+				arm64)  ARCH=aarch64 ;; \
+				arm/v7) ARCH=armv7hf ;; \
+				arm/v6) ARCH=rpi ;; \
+				386)    ARCH=i386 ;; \
+				*) echo "Cannot resolve balena arch: ARCH='${ARCH:-}' TARGETARCH='${TARGETARCH:-}' TARGETVARIANT='${TARGETVARIANT:-}'" >&2; exit 1 ;; \
+			esac ;; \
+	esac; \
+	echo "${ARCH}" > /balena-arch
+
+###################################################
 # Build the supervisor dependencies
 ###################################################
 FROM alpine:${ALPINE_VERSION} AS build-base
 
-ARG ARCH
 ARG NODE
 ARG NPM
 ARG FATRW_VERSION
@@ -106,11 +132,12 @@ RUN apk add --update --no-cache \
 	iptables~=1.8.9 \
 	ip6tables~=1.8.9
 
-ARG ARCH
 ARG VERSION=master
 ENV LED_FILE=/dev/null \
-	SUPERVISOR_IMAGE=balena/$ARCH-supervisor \
 	VERSION=$VERSION
+
+# Resolved at runtime by entry.sh to balena/<arch>-supervisor
+COPY --from=arch-info /balena-arch /balena-arch
 
 ###############################################################
 # Use the base image to run integration tests and for livepush
@@ -118,7 +145,6 @@ ENV LED_FILE=/dev/null \
 FROM runtime-base AS test
 
 ARG NPM
-ARG ARCH
 
 # We want to use as close to the final image when running tests
 # but we need npm so we install it here again
@@ -142,9 +168,11 @@ COPY typings ./typings
 COPY src ./src
 COPY test ./test
 
-# Fail-safe, check the architecture used by apk against the expected architecture
-# from the device type
-RUN APK_ARCH=$(./build-utils/apk-print-arch.sh); [ "$APK_ARCH" = "$ARCH" ] || (echo "Image architecture ($APK_ARCH) does not match the target architecture ($ARCH)" && exit 1)
+# Fail-safe, check the architecture used by apk against the resolved
+# balena arch (from %%BALENA_ARCH%% substitution or TARGETARCH-derived).
+RUN APK_ARCH=$(./build-utils/apk-print-arch.sh); \
+	ARCH=$(cat /balena-arch); \
+	[ "$APK_ARCH" = "$ARCH" ] || (echo "Image architecture ($APK_ARCH) does not match the target architecture ($ARCH)" && exit 1)
 
 # Run type checking and unit tests here
 # to prevent setting up a test environment that will

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,10 @@
+target "default" {
+  dockerfile = "Dockerfile.template"
+  platforms = [
+    "linux/amd64",
+    "linux/arm64",
+    "linux/arm/v7",
+    "linux/arm/v6",
+    "linux/386",
+  ]
+}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,11 +2,10 @@ version: '2.3'
 
 services:
   balena-supervisor-sut:
+    image: sut
     build:
       context: ./
       dockerfile: Dockerfile.template
-      args:
-        ARCH: ${ARCH:-amd64}
     command: ['/wait-for-it.sh', '--', '/usr/src/app/entry.sh']
     stop_grace_period: 3s
     # Use bridge networking for the tests
@@ -58,9 +57,6 @@ services:
       context: ./
       dockerfile: Dockerfile.template
       target: test
-      args:
-        # Change this if testing in another architecture
-        ARCH: ${ARCH:-amd64}
     command:
       [
         './test/lib/wait-for-it.sh',

--- a/entry.sh
+++ b/entry.sh
@@ -77,6 +77,12 @@ fi
 # not a problem.
 modprobe ip6_tables || true
 
+# Derive SUPERVISOR_IMAGE from the resolved balena arch unless one
+# was provided externally (e.g. tests).
+if [ -z "${SUPERVISOR_IMAGE}" ] && [ -r /balena-arch ]; then
+	export SUPERVISOR_IMAGE="balena/$(cat /balena-arch)-supervisor"
+fi
+
 if [ "${LIVEPUSH}" = "1" ]; then
 	exec npx nodemon --watch src --watch typings --ignore tests -e js,ts,json \
 		--exec node -r ts-node/register/transpile-only src/app.ts

--- a/entry.sh
+++ b/entry.sh
@@ -83,6 +83,16 @@ if [ -z "${SUPERVISOR_IMAGE}" ] && [ -r /balena-arch ]; then
 	export SUPERVISOR_IMAGE="balena/$(cat /balena-arch)-supervisor"
 fi
 
+# QEMU_CPU=arm1176 forces faithful Pi Zero CPU emulation when this image
+# runs under QEMU user-mode (e.g. CI on x86_64). On real Pi Zero hardware
+# QEMU isn't in the loop and this var is ignored. Without it, QEMU defaults
+# to a Cortex-A15-class CPU and exposes ARMv7+ features through HWCAP,
+# masking V8 codegen bugs that only fire on real ARMv6 silicon.
+case "$(cat /balena-arch)" in
+	rpi)     export QEMU_CPU=arm1176 ;;   # Pi Zero / Pi 1: ARM1176JZF-S
+	armv7hf) export QEMU_CPU=cortex-a7 ;; # Pi 2: Cortex-A7
+esac
+
 if [ "${LIVEPUSH}" = "1" ]; then
 	exec npx nodemon --watch src --watch typings --ignore tests -e js,ts,json \
 		--exec node -r ts-node/register/transpile-only src/app.ts


### PR DESCRIPTION
Bake and run compose tests against all platforms
to confirm there are no runtime failures on ARM architectures.

Change-type: patch
See: https://balena.fibery.io/Work/Improvement/Unblock-the-raspberrypi-pipeline-4203

---
**Closing note (2026-08-14):** Parking this for now. Baking and running the compose tests across platforms doesn't reproduce the node24/armv6 runtime failure, because the arm/v6 container — while built correctly — still runs on a 64-bit compose host. The last commit (QEMU_CPU emulation) was an attempt to force V8 down the real code paths; closing until we can validate reproduction on real 32-bit hardware. Branch `kyle/docker-test-all` is preserved. Ref: Unblock-the-raspberrypi-pipeline-4203.