### PR TITLE
Convert extra_hosts separator from `=` to `:`

### DIFF
--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -223,6 +223,15 @@ class ServiceImpl implements Service {
 			config.dnsSearch = [config.dnsSearch];
 		}
 
+		// Engine expects`host:ip` form, but the compose spec also accepts `host=ip`
+		// and compose-go outputs as `host=ip`. Normalise the separator to `:` so
+		// that either input format produces a valid container config.
+		if (Array.isArray(config.extraHosts)) {
+			config.extraHosts = config.extraHosts.map((entry) =>
+				entry.replace('=', ':'),
+			);
+		}
+
 		// Special case network modes
 		let serviceNetworkMode = false;
 		if (config.networkMode != null) {

--- a/test/unit/compose/service.spec.ts
+++ b/test/unit/compose/service.spec.ts
@@ -230,6 +230,27 @@ describe('compose/service: unit tests', () => {
 			});
 		});
 
+		it('normalizes extra_hosts entries to the host:ip format', async () => {
+			const s = await Service.fromComposeObject(
+				{
+					appId: '1234',
+					serviceName: 'foo',
+					releaseId: 2,
+					serviceId: 3,
+					imageId: 4,
+					composition: {
+						extraHosts: ['foo=127.0.0.1', 'bar:8.8.8.8'],
+					},
+				},
+				{ appName: 'test' } as any,
+			);
+
+			expect(s.config.extraHosts).to.deep.equal([
+				'foo:127.0.0.1',
+				'bar:8.8.8.8',
+			]);
+		});
+
 		it('should correctly handle large port ranges', async function () {
 			this.timeout(60000);
 			const s = await Service.fromComposeObject(


### PR DESCRIPTION
Engine expects `:` but compose-go from compose-parser outputs `=`.

Change-type: patch
Relates-to: https://github.com/balena-io-modules/balena-compose-parser/pull/28