### PR TITLE
Bump helios to 0.25.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 
 x-helios-image: &helios-image
-  image: ghcr.io/balena-io/helios:0.25.4
+  image: ghcr.io/balena-io/helios:0.25.8
 
 services:
   # This service can only be named `main` or `balena-supervisor` as older


### PR DESCRIPTION
- Patch duration string -> i64 parsing
- Support service.extra_hosts
- Validate target apps independently
- Allow forcing locks

Depends-on: https://github.com/balena-io/helios/pull/122
Closes: https://github.com/balena-os/balena-supervisor/issues/2525
Change-type: patch