### PR TITLE
Restore service to single container configuration pre v18 update

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -20,7 +20,7 @@ services:
       - mock-systemd
     volumes:
       - dbus:/shared/dbus
-      - services:/mnt/root/tmp/balena-supervisor/services
+      - tmp:/mnt/root/tmp/balena-supervisor/services
       - ./test/data/root:/mnt/root
       - ./test/data/root/mnt/boot:/mnt/boot
       - ./test/lib/wait-for-it.sh:/wait-for-it.sh
@@ -78,7 +78,7 @@ services:
     stop_grace_period: 3s
     volumes:
       - dbus:/shared/dbus
-      - services:/mnt/root/tmp/balena-supervisor/services
+      - tmp:/mnt/root/tmp/balena-supervisor/services
     # Set required supervisor configuration variables here
     environment:
       DOCKER_HOST: tcp://docker:2375
@@ -110,7 +110,7 @@ volumes:
     driver_opts:
       type: tmpfs
       device: tmpfs
-  services:
+  tmp:
     driver_opts:
       type: tmpfs
       device: tmpfs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,5 @@
 version: '2.3'
 
-x-helios-image: &helios-image
-  image: ghcr.io/balena-io/helios:0.25.4
-
 services:
   # This service can only be named `main` or `balena-supervisor` as older
   # devices will keep relying on the `/v6/supervisor_release` endpoint that
@@ -17,66 +14,3 @@ services:
       io.balena.features.balena-api: '1'
       io.balena.features.dbus: '1'
       io.balena.features.balena-socket: '1'
-
-  # This is the next generation supervisor service. When started, it becomes a proxy
-  # for calls between the existing supervisor and the balenaAPI and containers
-  helios:
-    <<: *helios-image
-    restart: on-failure
-    labels:
-      # Needed to get access to supervisor api variables
-      # and credentials
-      io.balena.features.supervisor-api: '1'
-      # Needed for access to DOCKER_HOST
-      io.balena.features.balena-socket: '1'
-      # Needed to stop the supervisor service
-      io.balena.features.dbus: '1'
-      # Needed to get access to the API credentials
-      io.balena.features.balena-api: '1'
-      # Needed to get Host OS metadata
-      io.balena.features.host-os.board-rev: '1'
-    environment:
-      - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
-      # Needed for locks and balenahup. This needs to match the device
-      # used for the `runtime` volume
-      - BALENA_HOST_RUNTIME_DIR=/tmp/balena-supervisor
-    volumes:
-      # Critical configurations
-      - config:/config/helios
-      # Request caching
-      - cache:/cache/helios
-      # Persistent system state data that can be reconstructed from
-      # the target state
-      - state:/local/helios
-      # Runtime directory. Data here does not persist after reboots
-      - runtime:/tmp/run
-
-  # The service below exposes the port on the network
-  # On balenaOS devices, this will probably be done by the OS and the
-  # access controlled via the firewall
-  helios-api:
-    <<: *helios-image
-    command: socat TCP-LISTEN:48484,reuseaddr,fork UNIX-CONNECT:/tmp/run/helios.sock
-    ports:
-      - 48484
-    depends_on:
-      - helios
-    volumes:
-      - runtime:/tmp/run
-    healthcheck:
-      test: ['CMD', 'wget', '-O', '-', '-q', 'http://127.0.0.1:48484/ping']
-
-volumes:
-  config:
-  state:
-    labels:
-      # the database version, can be bumped to re-create the state
-      io.balena.private.db-version: 0
-  cache:
-  runtime:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      # XXX: this directory needs to exist on the host before the container is started
-      device: /tmp/balena-supervisor

--- a/src/lib/supervisor-metadata.ts
+++ b/src/lib/supervisor-metadata.ts
@@ -36,6 +36,10 @@ const SUPERVISOR_APPS: { [arch: string]: SupervisorMetadata } = {
 	},
 };
 
+export function isSupervisorApp(appUuid: string): boolean {
+	return Object.values(SUPERVISOR_APPS).some(({ uuid }) => uuid === appUuid);
+}
+
 /**
  * Check if the supervisor in the target state belongs to the known
  * supervisors

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -19,6 +19,10 @@ import * as firewall from './lib/firewall';
 import * as constants from './lib/constants';
 import * as uname from './lib/uname';
 
+// FIXME: remove when we release supervisor v19
+import * as servicesManager from './compose/service-manager';
+import * as supervisorMetadata from './lib/supervisor-metadata';
+
 const startupConfigFields: config.ConfigKey[] = [
 	'uuid',
 	'listenPort',
@@ -32,6 +36,42 @@ const startupConfigFields: config.ConfigKey[] = [
 	'legacyAppsPresent',
 ];
 
+// This function removes any `helios` overrides in order to restore
+// the supervisor functionality as the only service.
+//
+// - It removes the port/endpoint overrides
+// - It stops helios
+//
+// Returns true if the changes were applied
+//
+// FIXME: remove when we release supervisor v19
+async function recoverFromOverrides() {
+	const { listenPortOverride, apiEndpointOverride } = await config.getMany([
+		'listenPortOverride',
+		'apiEndpointOverride',
+	]);
+	if (listenPortOverride != null || apiEndpointOverride != null) {
+		// stop helios-api
+		const [heliosApi] = (
+			await servicesManager.getAll(`service-name=helios-api`)
+		).filter(
+			(svc) =>
+				svc.appUuid != null && supervisorMetadata.isSupervisorApp(svc.appUuid),
+		);
+		if (heliosApi != null) {
+			await servicesManager.kill(heliosApi, { wait: true });
+		}
+
+		log.info('Removing supervisor overrides');
+		await db.models('config').del().where({ key: 'listenPortOverride' });
+		await db.models('config').del().where({ key: 'apiEndpointOverride' });
+
+		// terminate the process
+		log.info('restarting');
+		process.exit(1);
+	}
+}
+
 export class Supervisor {
 	private api: SupervisorAPI;
 
@@ -40,6 +80,10 @@ export class Supervisor {
 
 		await db.initialized();
 		await config.initialized();
+
+		// FIXME: remove when we release supervisor v19
+		await recoverFromOverrides();
+
 		await avahi.initialized();
 		log.debug('Starting logging infrastructure');
 		await logger.initialized();


### PR DESCRIPTION
We are re-working our release strategy around the new multi-container supervisor after some initial customer concerns. This removes the new services from the supervisor release composition, reverting commit e62c021b0c065b8f66164fe661754d7f796206c2.

For devices already on v18, this removes any overrides created by the new helios service and restarts the supervisor to restore its single-container operation. The extra services and their images will get removed on the next target state apply


## Release Notes

This release rolls back the changes in v18, that introduced a new service `helios` as part of the Balena Supervisor composition. This roll back comes after some customers voiced their questions and concerns with some of the implementation details. We will be addressing those concerns before re-releasing this multi-container supervisor. An announcement and communications will precede the release. 

For any users that already had updated to v18.0.0, this release removes the extra service restoring single-service functionality.  