### PR TITLE
Report the supervisor core service to backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
 version: '2.3'
 
 services:
-  # This service can only be named `main` or `balena-supervisor` as older
-  # devices will keep relying on the `/v6/supervisor_release` endpoint that
-  # identifies the supervisor image by that service name.
-  balena-supervisor:
+  # This service can only be named `main`, `balena-supervisor` or `core`
+  # in a multi-container supervisor, the API `supervisor_release` needs to be able to
+  # identify the "main" supervisor image so the `update-balena-supervisor` script works
+  # properly
+  core:
     build: ./
     privileged: true
     tty: true

--- a/src/compose/app.ts
+++ b/src/compose/app.ts
@@ -1015,6 +1015,7 @@ class AppImpl implements App {
 
 	public static async fromTargetState(
 		app: targetStateCache.DatabaseApp,
+		excludeSupervisor = true,
 	): Promise<App> {
 		const jsonVolumes = JSON.parse(app.volumes) ?? {};
 		const volumes = Object.keys(jsonVolumes).map((name) => {
@@ -1062,47 +1063,49 @@ class AppImpl implements App {
 			svc.labels?.['io.balena.image.store'] == null ||
 			svc.labels['io.balena.image.store'] === 'data';
 
+		let servicesToConstruct = JSON.parse(app.services ?? []).filter(
+			// For the host app, `io.balena.image.*` labels indicate special way
+			// to install the service image, so we ignore those we don't know how to
+			// handle yet. If a user app adds the labels, we treat those services
+			// just as any other
+			(svc: ServiceComposeConfig) =>
+				!app.isHost || (isService(svc) && isDataStore(svc)),
+		);
+
+		// Ignore the supervisor service unless specifically requested, since the supervisor
+		// cannot update itself
+		if (excludeSupervisor) {
+			servicesToConstruct = servicesToConstruct.filter(
+				(svc: ServiceComposeConfig) => !isSupervisor(app.uuid, svc.serviceName),
+			);
+		}
+
 		// In the db, the services are an array, but here we switch them to an
 		// object so that they are consistent
 		const services: Service[] = await Promise.all(
-			JSON.parse(app.services ?? [])
-				.filter(
-					// For the host app, `io.balena.image.*` labels indicate special way
-					// to install the service image, so we ignore those we don't know how to
-					// handle yet. If a user app adds the labels, we treat those services
-					// just as any other
-					(svc: ServiceComposeConfig) =>
-						!app.isHost || (isService(svc) && isDataStore(svc)),
-				)
-				// Ignore the supervisor service itself from the target state for now
-				// until the supervisor can update itself
-				.filter(
-					(svc: ServiceComposeConfig) =>
-						!isSupervisor(app.uuid, svc.serviceName),
-				)
-				.map(async (svc: ServiceComposeConfig) => {
-					// Try to fill the image id if the image is downloaded
-					let imageInfo: ImageInspectInfo | undefined;
-					try {
-						imageInfo = await imageManager.inspectByName(svc.image);
-					} catch (e: unknown) {
-						if (!isNotFoundError(e)) {
-							throw e;
-						}
+			servicesToConstruct.map(async (svc: ServiceComposeConfig) => {
+				// Try to fill the image id if the image is downloaded
+				let imageInfo: ImageInspectInfo | undefined;
+				try {
+					imageInfo = await imageManager.inspectByName(svc.image);
+				} catch (e: unknown) {
+					if (!isNotFoundError(e)) {
+						throw e;
 					}
+				}
 
-					const thisSvcOpts = {
-						...svcOpts,
-						imageInfo,
-						serviceName: svc.serviceName,
-					};
+				const thisSvcOpts = {
+					...svcOpts,
+					imageInfo,
+					serviceName: svc.serviceName,
+				};
 
-					// FIXME: Typings for DeviceMetadata
-					return await Service.fromComposeObject(
-						svc,
-						thisSvcOpts as unknown as DeviceMetadata,
-					);
-				}),
+				// FIXME: Typings for DeviceMetadata
+				return await Service.fromComposeObject(
+					svc,
+					thisSvcOpts as unknown as DeviceMetadata,
+				);
+			}),
 		);
 
 		return new AppImpl(

--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -43,6 +43,7 @@ import type {
 import { isRebootBreadcrumbSet } from '../lib/reboot';
 import { getBootTime } from '../lib/fs-utils';
 import * as extraFirmware from '../lib/extra-firmware';
+import { isSupervisor } from '../lib/supervisor-metadata';
 
 type ApplicationManagerEventEmitter = StrictEventEmitter<
 	EventEmitter,
@@ -929,7 +930,8 @@ export async function getState(): Promise<AppsReport> {
 	const [services, images, targetApps] = await Promise.all([
 		serviceManager.getState(),
 		imageManager.getState(),
-		dbFormat.getApps(),
+		// query target apps including the supervisor
+		dbFormat.getApps(false),
 	]);
 
 	type ServiceInfo = {
@@ -983,6 +985,16 @@ export async function getState(): Promise<AppsReport> {
 				continue;
 			}
 
+			// The supervisor service will not be on the current services list, so
+			// we manufacture its state when reporting
+			const serviceStatus =
+				appUuid != null && isSupervisor(appUuid, serviceName)
+					? { status: 'Running' }
+					: {
+							status: 'Downloading',
+							download_progress: 0,
+						};
+
 			// add target images that are pending downnload
 			stateFromImages.push({
 				appId,
@@ -990,8 +1002,7 @@ export async function getState(): Promise<AppsReport> {
 				image: imageName!,
 				commit,
 				serviceName,
-				status: 'Downloading',
-				download_progress: 0,
+				...serviceStatus,
 			});
 		}
 	}

--- a/src/device-state/db-format.ts
+++ b/src/device-state/db-format.ts
@@ -19,12 +19,14 @@ export async function getApp(id: number): Promise<InstancedApp> {
 	return await App.fromTargetState(dbApp);
 }
 
-export async function getApps(): Promise<InstancedAppState> {
+export async function getApps(
+	excludeSupervisor = true,
+): Promise<InstancedAppState> {
 	const dbApps = await getDBEntry();
 	const apps: InstancedAppState = {};
 	await Promise.all(
 		dbApps.map(async (app) => {
-			apps[app.appId] = await App.fromTargetState(app);
+			apps[app.appId] = await App.fromTargetState(app, excludeSupervisor);
 		}),
 	);
 	return apps;

--- a/src/lib/supervisor-metadata.ts
+++ b/src/lib/supervisor-metadata.ts
@@ -1,7 +1,4 @@
-export type SupervisorMetadata = {
-	uuid: string;
-	serviceName: string;
-};
+const SUPERVISOR_SVC_NAMES = ['main', 'balena-supervisor', 'core'];
 
 /**
  * Although it might feel unsettling to hardcode these ids here.
@@ -13,31 +10,16 @@ export type SupervisorMetadata = {
  * This will only be necessary until the supervisor becomes an actual app
  * on balena
  */
-const SUPERVISOR_APPS: { [arch: string]: SupervisorMetadata } = {
-	amd64: {
-		uuid: '52e35121417640b1b28a680504e4039b',
-		serviceName: 'balena-supervisor',
-	},
-	aarch64: {
-		uuid: '900de4f3cbac4b9bbd232885a35e407b',
-		serviceName: 'balena-supervisor',
-	},
-	armv7hf: {
-		uuid: '2e66a95795c149959c69472a8c2f92b8',
-		serviceName: 'balena-supervisor',
-	},
-	i386: {
-		uuid: '531b357e155c480cbec0fdd33041a1f5',
-		serviceName: 'balena-supervisor',
-	},
-	rpi: {
-		uuid: '6822565f766e413e96d9bebe2227cdcc',
-		serviceName: 'balena-supervisor',
-	},
+const SUPERVISOR_APPS: { [arch: string]: string } = {
+	amd64: '52e35121417640b1b28a680504e4039b',
+	aarch64: '900de4f3cbac4b9bbd232885a35e407b',
+	armv7hf: '2e66a95795c149959c69472a8c2f92b8',
+	i386: '531b357e155c480cbec0fdd33041a1f5',
+	rpi: '6822565f766e413e96d9bebe2227cdcc',
 };
 
 export function isSupervisorApp(appUuid: string): boolean {
-	return Object.values(SUPERVISOR_APPS).some(({ uuid }) => uuid === appUuid);
+	return Object.values(SUPERVISOR_APPS).some((uuid) => uuid === appUuid);
 }
 
 /**
@@ -49,13 +31,8 @@ export function isSupervisorApp(appUuid: string): boolean {
  *
  * TODO: remove this once the supervisor knows how to update itself
  */
-
 export const isSupervisor = (appUuid: string, svcName: string) => {
-	return (
-		Object.values(SUPERVISOR_APPS).filter(
-			({ uuid, serviceName }) =>
-				// Compare with `main` as well for compatibility with older supervisors
-				appUuid === uuid && (svcName === serviceName || svcName === 'main'),
-		).length > 0
+	return Object.values(SUPERVISOR_APPS).some(
+		(uuid) => appUuid === uuid && SUPERVISOR_SVC_NAMES.includes(svcName),
 	);
 };


### PR DESCRIPTION
The supervisor cannot update itself so its core service is removed from the target state before applying steps. However we do want the service to be reported so it shows up in the new `Supervisor services` table on the dashboard.

Change-type: patch