### PR TITLE
Pass correct value for restart policy 'no'

### DIFF
--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -95,10 +95,6 @@ export function createRestartPolicy(name?: string): string {
 		return 'always';
 	}
 
-	if (name === 'no') {
-		return '';
-	}
-
 	return name;
 }
 


### PR DESCRIPTION
The supervisor was passing an empty string '' when receiving `restart_policy: no`, this now passes the direct name which is required by engine v25

Change-type: patch