### PR TITLE
Clean up supervisor images in the database

### DIFF
--- a/src/compose/images.ts
+++ b/src/compose/images.ts
@@ -17,6 +17,7 @@ import {
 import * as LogTypes from '../lib/log-types';
 import * as logger from '../logging';
 import { ImageDownloadBackoffError } from './errors';
+import { isSupervisor } from '../lib/supervisor-metadata';
 
 import type { Service } from './service';
 import { strict as assert } from 'assert';
@@ -407,10 +408,12 @@ export async function cleanImageData(): Promise<void> {
 				// Ignore errors
 			}
 
-			// If the image is in the DB but not available in docker, return it
-			// for removal on the database
+			// If the image is in the DB but not available in docker, or the image belongs to
+			// the supervisor itself, return it for removal on the database
 			return supervisedImages.filter(
-				(image) => !isAvailableInDocker(image, dockerImages),
+				(image) =>
+					!isAvailableInDocker(image, dockerImages) ||
+					isSupervisor(image.appUuid, image.serviceName),
 			);
 		},
 	);


### PR DESCRIPTION
On supervisor v18.2.0, we renamed the supervisor service to `core` in the [supervisor
composition](https://github.com/balena-os/balena-supervisor/blob/v18.2.0/docker-compose.yml). That change also updated the [isSupervisor](https://github.com/balena-os/balena-supervisor/blob/v18.2.0/src/lib/supervisor-metadata.ts#L34) filter in the supervisor-metadata module.

The problem is that when updating to v18.2.0, the following race condition may happen

- The device is on v17.8.5, and the user updates the supervisor on the dashboard to v18.2.0. The target state changes
- Before the update-balena-supervisor script can run, supervisor v17.8.5, sees the new `core` service which it not part of its filter list and creates the service and image on the database.
- Eventually supervisor v18.2.0 runs, it knows to filter `core` and tries to remove the image, but its using the image itself, so it gets stuck in a loop trying to remove the image and failing.

This adds a `isSupervisor` check to the initial application manager image cleanup to avoid the issue happening altogether.

If a customer is stuck in the delete loop, updating to this supervisor should fix it.

Change-type: patch

## Release notes

Fixes an issue introduced by the renaming of the supervisor service to `core`, where the old supervisor could install the `core` container and image, and the new supervisor would not be able to remove the image due to the image being used by the current supervisor container. This change adds a cleanup step to avoid the image delete loop and restore operation. 