### PR TITLE
Recover from an orphaned service relay override

### DIFF
--- a/src/lib/supervisor-metadata.ts
+++ b/src/lib/supervisor-metadata.ts
@@ -18,6 +18,9 @@ const SUPERVISOR_APPS: { [arch: string]: string } = {
 	rpi: '6822565f766e413e96d9bebe2227cdcc',
 };
 
+export const isSupervisorApp = (appUuid: string) =>
+	Object.values(SUPERVISOR_APPS).includes(appUuid);
+
 /**
  * Check if the supervisor in the target state belongs to the known
  * supervisors
@@ -28,7 +31,5 @@ const SUPERVISOR_APPS: { [arch: string]: string } = {
  * TODO: remove this once the supervisor knows how to update itself
  */
 export const isSupervisor = (appUuid: string, svcName: string) => {
-	return Object.values(SUPERVISOR_APPS).some(
-		(uuid) => appUuid === uuid && SUPERVISOR_SVC_NAMES.includes(svcName),
-	);
+	return isSupervisorApp(appUuid) && SUPERVISOR_SVC_NAMES.includes(svcName);
 };

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -18,6 +18,8 @@ import * as avahi from './lib/avahi';
 import * as firewall from './lib/firewall';
 import * as constants from './lib/constants';
 import * as uname from './lib/uname';
+import * as servicesManager from './compose/service-manager';
+import * as supervisorMetadata from './lib/supervisor-metadata';
 
 const startupConfigFields: config.ConfigKey[] = [
 	'uuid',
@@ -32,6 +34,51 @@ const startupConfigFields: config.ConfigKey[] = [
 	'legacyAppsPresent',
 ];
 
+async function recoverFromOrphanedApiEndpointOverride() {
+	const { apiEndpointOverride, listenPort, listenPortOverride } =
+		await config.getMany([
+			'apiEndpointOverride',
+			'listenPort',
+			'listenPortOverride',
+		]);
+
+	// Helios takeover moves the legacy API to listenPortOverride and proxies the
+	// original loopback endpoint through the service-relay sidecar. Preserve all
+	// other endpoint overrides, as they may be deliberately configured proxies.
+	if (
+		listenPortOverride == null ||
+		apiEndpointOverride !== `http://127.0.0.1:${listenPort}`
+	) {
+		return;
+	}
+
+	let relayRunning: boolean;
+	try {
+		relayRunning = (
+			await servicesManager.getAll('service-name=service-relay')
+		).some(
+			(service) =>
+				service.appUuid != null &&
+				supervisorMetadata.isSupervisorApp(service.appUuid) &&
+				service.status === 'Running',
+		);
+	} catch (error) {
+		log.warn(
+			'Could not determine service-relay status; preserving API endpoint override',
+			error,
+		);
+		return;
+	}
+	if (relayRunning) {
+		return;
+	}
+
+	log.warn(
+		'Removing API endpoint override because service-relay is not running',
+	);
+	await db.models('config').where({ key: 'apiEndpointOverride' }).delete();
+}
+
 export class Supervisor {
 	private api: SupervisorAPI;
 
@@ -40,6 +87,7 @@ export class Supervisor {
 
 		await db.initialized();
 		await config.initialized();
+		await recoverFromOrphanedApiEndpointOverride();
 		await avahi.initialized();
 		log.debug('Starting logging infrastructure');
 		await logger.initialized();


### PR DESCRIPTION
## Summary

- recognize the exact loopback configuration installed by Helios takeover
- verify that a managed `service-relay` container is running during Supervisor startup
- remove only the orphaned `apiEndpointOverride` when the relay is absent
- preserve unrelated endpoint overrides and `listenPortOverride`

## Problem

If Helios or `service-relay` disappears while its takeover values remain in the Supervisor database, the Supervisor keeps sending balenaCloud requests to an unused loopback port. It then cannot fetch target state or recover through normal updates.

This repairs that orphaned state before API clients are initialized, so all cloud request paths return to the configured balenaCloud endpoint without changing request or retry behavior.

The matching Helios change in https://github.com/balena-io/helios/pull/143 makes takeover restore both overrides when the relay returns.

## Testing

- `npm run lint`
- `npm run test:build`
- `git diff --check`
