### PR TITLE
Improve recoverability of core-next takeover of the supervisor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 
 x-helios-image: &helios-image
-  image: ghcr.io/balena-io/helios:0.25.24
+  image: ghcr.io/balena-io/helios:0.25.26
 
 services:
   # This service can only be named `main`, `balena-supervisor` or `core`
@@ -82,6 +82,10 @@ volumes:
       # the database version, can be bumped to re-create the state
       io.balena.private.db-version: 0
   cache:
+    labels:
+      # the cache version, can be bumped to force re-creation of the volume
+      # on a new release
+      io.balena.private.version: "0"
   runtime:
     driver: local
     driver_opts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,8 +70,8 @@ services:
     volumes:
       - runtime:/tmp/run
     environment:
-      # Only send error logs to dashboard
-      - BALENA_LOGS_LEVEL=error
+      # Socat errors are not really useful, don't send them to the dashboard
+      - BALENA_LOGS_LEVEL=none
     healthcheck:
       test: ['CMD', 'wget', '-O', '-', '-q', 'http://127.0.0.1:48484/ping']
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
   # for calls between the existing supervisor and the balenaAPI and containers
   core-next:
     <<: *helios-image
-    restart: on-failure
+    restart: always
     # required to distinguish between stderr/stdout, the supervisor defaults to true
     tty: false
     labels:


### PR DESCRIPTION
This includes robustness improvements for the helios takeover to allow the service to recover from an incomplete takeover.

This PR also makes sure `core-next` uses the `always` restart policy and disables log sending for `service-relay` to the dashboard. The `socat` service will crash if the socket is not available, but any errors with `core-next` should be already evident.

Change-type: patch