### PR TITLE
Update helios to v0.25.24

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 
 x-helios-image: &helios-image
-  image: ghcr.io/balena-io/helios:0.25.21
+  image: ghcr.io/balena-io/helios:0.25.24
 
 services:
   # This service can only be named `main`, `balena-supervisor` or `core`


### PR DESCRIPTION
    Includes:
    * Improve storage of published ports
    * Support for additional compose properties
    * Reduce log level for local API 5xx responses


Change-type: patch