### PR TITLE
Use `/tmp` as host runtime dir

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,9 +40,9 @@ services:
       io.balena.features.host-os.board-rev: '1'
     environment:
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
-      # Needed for locks and balenahup. This needs to match the device
+      # Needed for locks and balenahup. This needs to match the path
       # used for the `runtime` volume
-      - BALENA_HOST_RUNTIME_DIR=/tmp/balena-supervisor
+      - BALENA_HOST_RUNTIME_DIR=/tmp
       # Only send error logs to dashboard
       - BALENA_LOGS_LEVEL=error
     volumes:
@@ -91,5 +91,4 @@ volumes:
     driver_opts:
       type: none
       o: bind
-      # XXX: this directory needs to exist on the host before the container is started
-      device: /tmp/balena-supervisor
+      device: /tmp


### PR DESCRIPTION
The path used as the directory for the `local` volume driver needs to exist before starting the container. On reboot, if helios starts before the supervisor, the `/tmp/balena-supervisor` path won't exist resulting in the container failing to start before setting the restart policy and will never be started again.

This makes `/tmp` the host runtime directory, preventing the issue. Note that this also means that some paths that lived under `/tmp/balena-supervisor` now will be created under `/tmp`, e.g. `/tmp/helios.sock`, `/tmp/balenahup`

Change-type: patch