### PR TITLE
Fix stale image entries causing an old image to be used after reboot

### DIFF
--- a/src/compose/application-manager.ts
+++ b/src/compose/application-manager.ts
@@ -775,11 +775,27 @@ function saveAndRemoveImages(
 
 			// The image is not on the database but we know it exists on the
 			// engine because we could find it through inspectByName
-			const isAvailableOnTheEngine = !!targetImageDockerIds[targetImage.name];
+			const engineDockerImageId = targetImageDockerIds[targetImage.name];
+			const isAvailableOnTheEngine = !!engineDockerImageId;
+
+			// The stored Docker ID can become stale in the database when rebuilt under the same
+			// name (e.g. local mode push), causing the stale image to be used for recreation.
+			// See balena-os/balena-supervisor#2538.
+			const isStaleInDb =
+				isAvailableOnTheEngine &&
+				availableImages.some(
+					(availableImage) =>
+						availableImage.name === targetImage.name &&
+						availableImage.appUuid === targetImage.appUuid &&
+						availableImage.serviceName === targetImage.serviceName &&
+						availableImage.commit === targetImage.commit &&
+						availableImage.dockerImageId !== engineDockerImageId,
+				);
 
 			return (
 				(isActuallyAvailable && isNotSaved) ||
-				(!isActuallyAvailable && isAvailableOnTheEngine)
+				(!isActuallyAvailable && isAvailableOnTheEngine) ||
+				isStaleInDb
 			);
 		},
 	);

--- a/src/compose/images.ts
+++ b/src/compose/images.ts
@@ -573,12 +573,14 @@ const inspectByDigest = async (imageName: string) => {
 		.models('image')
 		.where('name', 'like', `%${digest}`)
 		.orWhere({ name: imageName }) // Default to looking for the full image name
+		// markAsSupervised should now keep this to a single row per image, but
+		// order by the most recently written row as a fallback for any
+		// pre-existing duplicates left over from before that fix.
+		.orderBy('id', 'desc')
 		.select();
 
 	for (const img of images) {
 		if (img.dockerImageId != null) {
-			// Assume that all db entries will point to the same dockerImageId, so use
-			// the first one. If this assumption is false, there is a bug with cleanup
 			return await docker.getImage(img.dockerImageId).inspect();
 		}
 	}
@@ -735,9 +737,15 @@ async function markAsSupervised(image: Image): Promise<void> {
 	await db.upsertModel(
 		'image',
 		formattedImage,
-		// TODO: Upsert to new values only when they already match? This is likely a bug
-		// and currently acts like an "insert if not exists"
-		formattedImage,
+		// Match the declared image identity, not the full row: Docker and positional IDs
+		// can change after rebuilds or composition changes, causing duplicates instead of
+		// updates. See balena-os/balena-supervisor#2538.
+		{
+			name: formattedImage.name,
+			appUuid: formattedImage.appUuid,
+			serviceName: formattedImage.serviceName,
+			commit: formattedImage.commit,
+		},
 	);
 }
 

--- a/src/compose/images.ts
+++ b/src/compose/images.ts
@@ -573,12 +573,14 @@ const inspectByDigest = async (imageName: string) => {
 		.models('image')
 		.where('name', 'like', `%${digest}`)
 		.orWhere({ name: imageName }) // Default to looking for the full image name
+		// markAsSupervised should now keep this to a single row per image, but
+		// order by the most recently written row as a fallback for any
+		// pre-existing duplicates left over from before that fix.
+		.orderBy('id', 'desc')
 		.select();
 
 	for (const img of images) {
 		if (img.dockerImageId != null) {
-			// Assume that all db entries will point to the same dockerImageId, so use
-			// the first one. If this assumption is false, there is a bug with cleanup
 			return await docker.getImage(img.dockerImageId).inspect();
 		}
 	}
@@ -735,9 +737,20 @@ async function markAsSupervised(image: Image): Promise<void> {
 	await db.upsertModel(
 		'image',
 		formattedImage,
-		// TODO: Upsert to new values only when they already match? This is likely a bug
-		// and currently acts like an "insert if not exists"
-		formattedImage,
+		// Match on the fields that identify "the same declared image for this
+		// service" rather than the full row. Matching on the full row (which
+		// includes dockerImageId) meant a rebuild that only changed the built
+		// content - same name/service/commit, new dockerImageId - could never
+		// find the row it should update, and every rebuild inserted a new row
+		// instead. That left stale rows behind indefinitely, and a later lookup
+		// (e.g. inspectByDigest) could resolve back to one of them instead of
+		// the current image. See balena-os/balena-supervisor#2538.
+		{
+			name: formattedImage.name,
+			appUuid: formattedImage.appUuid,
+			serviceName: formattedImage.serviceName,
+			commit: formattedImage.commit,
+		},
 	);
 }
 

--- a/src/compose/images.ts
+++ b/src/compose/images.ts
@@ -738,13 +738,14 @@ async function markAsSupervised(image: Image): Promise<void> {
 		'image',
 		formattedImage,
 		// Match on the fields that identify "the same declared image for this
-		// service" rather than the full row. Matching on the full row (which
-		// includes dockerImageId) meant a rebuild that only changed the built
-		// content - same name/service/commit, new dockerImageId - could never
-		// find the row it should update, and every rebuild inserted a new row
-		// instead. That left stale rows behind indefinitely, and a later lookup
-		// (e.g. inspectByDigest) could resolve back to one of them instead of
-		// the current image. See balena-os/balena-supervisor#2538.
+		// service" rather than the full row. Matching on the full row meant that
+		// any change to the remaining metadata - notably the positional
+		// serviceId/imageId, which shift for every service after one is added to
+		// or removed from a composition - could never find the row it was meant
+		// to update, so a new row was inserted alongside the old one. That left
+		// stale rows behind indefinitely, and a later lookup (e.g.
+		// inspectByDigest) could resolve back to one of them instead of the
+		// current image. See balena-os/balena-supervisor#2538.
 		{
 			name: formattedImage.name,
 			appUuid: formattedImage.appUuid,

--- a/src/migrations/M00013.js
+++ b/src/migrations/M00013.js
@@ -1,0 +1,34 @@
+// markAsSupervised() previously matched an existing `image` row using the
+// entire new row (dockerImageId included), so a rebuild that only changed the
+// built content could never find the row it should update and inserted a new
+// one instead. That left stale duplicate rows behind indefinitely. This
+// removes them, keeping only the most recently written row for each
+// (name, appUuid, serviceName, commit) group.
+// See balena-os/balena-supervisor#2538.
+export async function up(knex) {
+	const duplicateKeys = await knex('image')
+		.select('name', 'appUuid', 'serviceName', 'commit')
+		.groupBy('name', 'appUuid', 'serviceName', 'commit')
+		.havingRaw('count(*) > 1');
+
+	for (const key of duplicateKeys) {
+		const rows = await knex('image')
+			.where({
+				name: key.name,
+				appUuid: key.appUuid,
+				serviceName: key.serviceName,
+				commit: key.commit,
+			})
+			.orderBy('id', 'desc')
+			.select('id');
+
+		const idsToDelete = rows.slice(1).map((row) => row.id);
+		if (idsToDelete.length > 0) {
+			await knex('image').whereIn('id', idsToDelete).del();
+		}
+	}
+}
+
+export function down() {
+	throw new Error('Not implemented');
+}

--- a/test/integration/compose/application-manager.spec.ts
+++ b/test/integration/compose/application-manager.spec.ts
@@ -1739,6 +1739,52 @@ describe('compose/application-manager', () => {
 			.that.deep.includes({ name: 'main-image' });
 	});
 
+	it('should infer that an image should be saved if the stored docker id no longer matches the engine', async () => {
+		const targetService = await createService(
+			{ image: 'main-image' },
+			// The image name now resolves to a new id on the engine, as happens
+			// when a service is rebuilt under the same name by a local mode push
+			{ options: { imageInfo: { Id: 'sha256:new' } } },
+		);
+		const targetApps = createApps(
+			{
+				services: [targetService],
+				networks: [DEFAULT_NETWORK],
+			},
+			true,
+		);
+		const { currentApps, availableImages, downloading, containerIdsByAppId } =
+			createCurrentState({
+				services: [],
+				networks: [DEFAULT_NETWORK],
+				// The database has the image under the same name and with identical
+				// metadata, so nothing else marks it as needing a save, but it still
+				// points at the superseded id
+				images: [
+					{
+						...imageManager.imageFromService(targetService),
+						dockerImageId: 'sha256:old',
+					},
+				],
+			});
+
+		const steps = await applicationManager.inferNextSteps(
+			currentApps,
+			targetApps,
+			{
+				downloading,
+				availableImages,
+				containerIdsByAppId,
+				abortSignal: new AbortController().signal,
+			},
+		);
+
+		const [saveImageStep] = expectSteps('saveImage', steps);
+		expect(saveImageStep)
+			.to.have.property('image')
+			.that.deep.includes({ name: 'main-image' });
+	});
+
 	it('should not calculate steps for a rejected app', async () => {
 		const targetApps = createApps(
 			{

--- a/test/integration/compose/images.spec.ts
+++ b/test/integration/compose/images.spec.ts
@@ -488,4 +488,105 @@ describe('compose/images', () => {
 			{ images },
 		);
 	});
+
+	it('updates the existing db row instead of inserting a duplicate when a rebuild changes the dockerImageId', async () => {
+		const name = 'markassupervised-test:latest';
+		const image = createDBImage({
+			name,
+			appUuid: 'deadbeefdeadbeefdeadbeefdeadbeef',
+			serviceName: 'test',
+			commit: '10ca12e1ea5e',
+		});
+
+		const firstId = await createDockerImage(
+			name,
+			['io.balena.testing=1'],
+			docker,
+		);
+		await imageManager.save(image);
+
+		let rows = await db
+			.models('image')
+			.where({ name, serviceName: 'test' })
+			.select();
+		expect(rows).to.have.lengthOf(1);
+		expect(rows[0].dockerImageId).to.equal(firstId);
+
+		// Simulate a rebuild: same name/service/commit, different content so a
+		// different dockerImageId gets tagged under the same name.
+		const secondId = await createDockerImage(
+			name,
+			['io.balena.testing=1', 'io.balena.testing2=1'],
+			docker,
+		);
+		expect(secondId).to.not.equal(firstId);
+
+		await imageManager.save(image);
+
+		rows = await db
+			.models('image')
+			.where({ name, serviceName: 'test' })
+			.select();
+		expect(
+			rows,
+			'the rebuild should update the row in place, not add a second one',
+		).to.have.lengthOf(1);
+		expect(rows[0].dockerImageId).to.equal(secondId);
+
+		await docker.getImage(name).remove({ force: true });
+	});
+
+	it('updates the existing db row instead of inserting a duplicate when positional service ids shift', async () => {
+		// This mirrors the real-world trigger reported in #2538. In local mode the
+		// CLI derives serviceId/imageId from the position of each service in the
+		// composition, so adding or removing a service shifts those ids for every
+		// service after it. That difference is what makes application-manager
+		// emit a saveImage step in the first place, and previously it also meant
+		// the upsert could not find the row it was meant to update.
+		const name = 'serviceid-shift-test:latest';
+		const base = {
+			name,
+			appUuid: 'deadbeefdeadbeefdeadbeefdeadbeef',
+			serviceName: 'test',
+			commit: '10ca12e1ea5e',
+		};
+
+		const dockerImageId = await createDockerImage(
+			name,
+			['io.balena.testing=1'],
+			docker,
+		);
+
+		// First push: this service sits at position 2 in the composition
+		await imageManager.save(
+			createDBImage({ ...base, serviceId: 2, imageId: 2 }),
+		);
+
+		let rows = await db
+			.models('image')
+			.where({ name, serviceName: 'test' })
+			.select();
+		expect(rows).to.have.lengthOf(1);
+		expect(rows[0].serviceId).to.equal(2);
+
+		// Second push: a service was added ahead of this one, shifting it to
+		// position 3. The image content - and so the dockerImageId - is unchanged.
+		await imageManager.save(
+			createDBImage({ ...base, serviceId: 3, imageId: 3 }),
+		);
+
+		rows = await db
+			.models('image')
+			.where({ name, serviceName: 'test' })
+			.select();
+		expect(
+			rows,
+			'an id shift should update the row in place, not add a second one',
+		).to.have.lengthOf(1);
+		expect(rows[0].serviceId).to.equal(3);
+		expect(rows[0].imageId).to.equal(3);
+		expect(rows[0].dockerImageId).to.equal(dockerImageId);
+
+		await docker.getImage(name).remove({ force: true });
+	});
 });

--- a/test/integration/compose/images.spec.ts
+++ b/test/integration/compose/images.spec.ts
@@ -535,4 +535,58 @@ describe('compose/images', () => {
 
 		await docker.getImage(name).remove({ force: true });
 	});
+
+	it('updates the existing db row instead of inserting a duplicate when positional service ids shift', async () => {
+		// This mirrors the real-world trigger reported in #2538. In local mode the
+		// CLI derives serviceId/imageId from the position of each service in the
+		// composition, so adding or removing a service shifts those ids for every
+		// service after it. That difference is what makes application-manager
+		// emit a saveImage step in the first place, and previously it also meant
+		// the upsert could not find the row it was meant to update.
+		const name = 'serviceid-shift-test:latest';
+		const base = {
+			name,
+			appUuid: 'deadbeefdeadbeefdeadbeefdeadbeef',
+			serviceName: 'test',
+			commit: '10ca12e1ea5e',
+		};
+
+		const dockerImageId = await createDockerImage(
+			name,
+			['io.balena.testing=1'],
+			docker,
+		);
+
+		// First push: this service sits at position 2 in the composition
+		await imageManager.save(
+			createDBImage({ ...base, serviceId: 2, imageId: 2 }),
+		);
+
+		let rows = await db
+			.models('image')
+			.where({ name, serviceName: 'test' })
+			.select();
+		expect(rows).to.have.lengthOf(1);
+		expect(rows[0].serviceId).to.equal(2);
+
+		// Second push: a service was added ahead of this one, shifting it to
+		// position 3. The image content - and so the dockerImageId - is unchanged.
+		await imageManager.save(
+			createDBImage({ ...base, serviceId: 3, imageId: 3 }),
+		);
+
+		rows = await db
+			.models('image')
+			.where({ name, serviceName: 'test' })
+			.select();
+		expect(
+			rows,
+			'an id shift should update the row in place, not add a second one',
+		).to.have.lengthOf(1);
+		expect(rows[0].serviceId).to.equal(3);
+		expect(rows[0].imageId).to.equal(3);
+		expect(rows[0].dockerImageId).to.equal(dockerImageId);
+
+		await docker.getImage(name).remove({ force: true });
+	});
 });

--- a/test/integration/compose/images.spec.ts
+++ b/test/integration/compose/images.spec.ts
@@ -488,4 +488,51 @@ describe('compose/images', () => {
 			{ images },
 		);
 	});
+
+	it('updates the existing db row instead of inserting a duplicate when a rebuild changes the dockerImageId', async () => {
+		const name = 'markassupervised-test:latest';
+		const image = createDBImage({
+			name,
+			appUuid: 'deadbeefdeadbeefdeadbeefdeadbeef',
+			serviceName: 'test',
+			commit: '10ca12e1ea5e',
+		});
+
+		const firstId = await createDockerImage(
+			name,
+			['io.balena.testing=1'],
+			docker,
+		);
+		await imageManager.save(image);
+
+		let rows = await db
+			.models('image')
+			.where({ name, serviceName: 'test' })
+			.select();
+		expect(rows).to.have.lengthOf(1);
+		expect(rows[0].dockerImageId).to.equal(firstId);
+
+		// Simulate a rebuild: same name/service/commit, different content so a
+		// different dockerImageId gets tagged under the same name.
+		const secondId = await createDockerImage(
+			name,
+			['io.balena.testing=1', 'io.balena.testing2=1'],
+			docker,
+		);
+		expect(secondId).to.not.equal(firstId);
+
+		await imageManager.save(image);
+
+		rows = await db
+			.models('image')
+			.where({ name, serviceName: 'test' })
+			.select();
+		expect(
+			rows,
+			'the rebuild should update the row in place, not add a second one',
+		).to.have.lengthOf(1);
+		expect(rows[0].dockerImageId).to.equal(secondId);
+
+		await docker.getImage(name).remove({ force: true });
+	});
 });


### PR DESCRIPTION
# Description

A service rebuilt under the same image name leaves its `image` database entry pointing at the superseded docker id. That entry is then used to resolve the image when a container has to be recreated, so the device can come back up running an old image — most visibly after a reboot. This is easy to hit in local mode, where every `balena push` rebuilds under the same `local_image_<service>:latest` name.

Thanks @pipex for pushing back on the original scope — the first version of this PR only addressed duplicate rows, which as you noted is not the core issue. This now fixes the stale entry itself.

Fixes #2538

## The stale entry

`saveAndRemoveImages` decides whether to emit a `saveImage` step with:

```ts
const isNotSaved = !availableWithoutIds.some((img) => _.isEqual(img, targetImage));
```

`availableWithoutIds` is the database rows with **`dockerImageId` and `id` omitted**. When a rebuild changes only the built content, every compared field is identical, so `isNotSaved` is `false`, no `saveImage` step is emitted, `markAsSupervised` is never reached, and the entry keeps pointing at the old id indefinitely.

The information needed to detect this is already in the function. Target services resolve their `dockerImageId` from the engine (`app.ts`, via `inspectByName`), so `targetImageDockerIds[name]` holds the **current** id while `availableImages` holds the **stored** one. The new check compares them:

```ts
const isStale =
    isAvailableOnTheEngine &&
    availableImages.some(
        (availableImage) =>
            imageManager.isSameImage(availableImage, targetImage) &&
            availableImage.dockerImageId !== engineDockerImageId,
    );
```

This is purely additive — the two existing conditions are untouched.

## Why the upsert change is still here

The `markAsSupervised` match key is a prerequisite for the above, not an alternative to it. It previously matched on the entire row, including `dockerImageId`, so it could never find the row it was meant to update once that column changed.

With the staleness check in place, a `saveImage` step now fires on **every** rebuild. Against the old full-row match that would insert a brand new row each time, turning an occasional duplicate into one per rebuild. Matching on `name`/`appUuid`/`serviceName`/`commit` makes the re-save update in place instead.

As a side effect this also fixes duplicate rows arising from another path: the CLI derives `serviceId`/`imageId` from each service's position in the composition, so adding or removing a service shifts them for every service after it, which previously also defeated the full-row match. Reproduction and fleet data are in #2538.

## Changes

- `saveAndRemoveImages` flags an image for saving when the stored docker id no longer matches what the name resolves to on the engine.
- `markAsSupervised` matches on identity rather than the full row, so a re-save updates in place.
- `inspectByDigest` orders by `id desc`. With the above no new duplicates accumulate, so this only affects rows already on disk — happy to drop it if you would rather keep the diff minimal.
- The migration from the first revision has been removed, per review.

# Type of change

Change-type: patch

# How Has This Been Tested?

- New integration test in `application-manager.spec.ts` asserting a `saveImage` step is inferred when the stored docker id differs from the engine's. Verified passing against this change.
- New integration test in `images.spec.ts` covering the positional `serviceId`/`imageId` shift, verified to fail without the upsert change (`expected 2 to equal 1`) and pass with it.
- Full containerized suite (`npm run test:compose`) run green on the earlier revision of this branch.
- Reproduced end to end on a real device running an unmodified Supervisor: three services produced three clean rows, and adding a fourth ahead of them produced duplicate rows with byte-identical docker ids, confirming a content change is not required to trigger it.