### PR TITLE
Update helios to v0.25.28

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 
 x-helios-image: &helios-image
-  image: ghcr.io/balena-io/helios:0.25.26
+  image: ghcr.io/balena-io/helios:0.25.28
 
 services:
   # This service can only be named `main`, `balena-supervisor` or `core`


### PR DESCRIPTION
The changes in balena-io/helios#149 cleanup the takeover breadcrumb in case of a failed takeover check to avoid unnecessary restarts.

Change-type: patch
Relates-to: balena-io/helios#149