### PR TITLE
Prevent the supervisor from managing extension containers volumes

### DIFF
--- a/src/compose/volume-manager.ts
+++ b/src/compose/volume-manager.ts
@@ -128,7 +128,9 @@ export async function removeOrphanedVolumes(
 		.map((m) => m.Name!)
 		.uniq()
 		.value();
-	const volumeNames = (dockerVolumes.Volumes ?? []).map((v) => v.Name);
+	const volumeNames = (dockerVolumes.Volumes ?? [])
+		.filter((v) => v.Labels?.['io.balena.image.class'] !== 'overlay')
+		.map((v) => v.Name);
 
 	const volumesToRemove = _.difference(
 		volumeNames,

--- a/src/compose/volume.ts
+++ b/src/compose/volume.ts
@@ -124,7 +124,7 @@ class VolumeImpl implements Volume {
 		name: string;
 		appId: number;
 	} {
-		const match = name.match(/(\d+)_(\S+)/);
+		const match = name.match(/^(\d+)_(\S+)/);
 		if (match == null) {
 			throw new VolumeNameParsingError(
 				`Could not detect volume data from docker name: ${name}`,

--- a/test/integration/compose/volume-manager.spec.ts
+++ b/test/integration/compose/volume-manager.spec.ts
@@ -325,5 +325,31 @@ describe('compose/volume-manager', () => {
 				docker.getVolume('other-volume').remove(),
 			]);
 		});
+
+		it('keeps overlay extension volumes that have no container references', async () => {
+			await Promise.all([
+				docker.createVolume({
+					Name: 'some-volume',
+				}),
+				docker.createVolume({
+					Name: 'ext_kernel-modules_417a6887f4b0_boot',
+					Labels: {
+						'io.balena.image.class': 'overlay',
+					},
+				}),
+			]);
+
+			await expect(volumeManager.removeOrphanedVolumes([])).to.not.be.rejected;
+
+			await expect(
+				docker.getVolume('ext_kernel-modules_417a6887f4b0_boot').inspect(),
+			).to.not.be.rejected;
+
+			// Asserting the unowned volume went confirms the sweep actually ran
+			await expect(docker.getVolume('some-volume').inspect()).to.be.rejected;
+
+			// Cleanup
+			await docker.getVolume('ext_kernel-modules_417a6887f4b0_boot').remove();
+		});
 	});
 });

--- a/test/unit/compose/volume.spec.ts
+++ b/test/unit/compose/volume.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { Volume } from '~/src/compose/volume';
+import { Volume, VolumeNameParsingError } from '~/src/compose/volume';
 
 describe('compose/volume: unit tests', () => {
 	describe('creating a volume from a compose object', () => {
@@ -126,6 +126,27 @@ describe('compose/volume: unit tests', () => {
 					Scope: 'local',
 				}),
 			).to.throw;
+		});
+
+		it('should not misparse extension-owned boot volumes as managed volumes', () => {
+			// The extension runtime creates /boot volumes named
+			// ext_<svc>_<12-hex-digest>_boot.These must be ignored as
+			// unmanaged volumes (VolumeNameParsingError).
+			for (const Name of [
+				'ext_kernel-modules_417a6887f4b0_boot',
+				'ext_kernel-modules_1cddd24884f3_boot',
+			]) {
+				expect(() =>
+					Volume.fromDockerVolume({
+						Driver: 'local',
+						Name,
+						Mountpoint: `/var/lib/docker/volumes/${Name}/_data`,
+						Labels: {},
+						Options: {},
+						Scope: 'local',
+					}),
+				).to.throw(VolumeNameParsingError);
+			}
 		});
 
 		it('should correctly parse docker volumes', () => {


### PR DESCRIPTION
Relates to: https://balena.fibery.io/Work/Project/Hostapp-overlay-extensions---supervisor-integration-2333
