### PR TITLE
Update debian docker image dependency to stable-slim

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -52,7 +52,7 @@ RUN npm ci --build-from-source=sqlite3 --sqlite=/usr/lib
 # musl. We hack around this by copying the binary and its library
 # dependencies to the final image
 ###################################################################
-FROM debian:bookworm-slim AS journal
+FROM debian:stable-slim AS journal
 
 RUN apt-get update && apt-get install -y --no-install-recommends systemd
 


### PR DESCRIPTION
For some reason `bookwork-slim` is no longer generating linux/arm/v5 images which is causing supervisor releases to fail to build

Change-type: patch