### PR TITLE
Add support for unix sockets as the apiEndpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 
 x-helios-image: &helios-image
-  image: ghcr.io/balena-io/helios:0.25.28
+  image: ghcr.io/balena-io/helios:0.26.3
 
 services:
   # This service can only be named `main`, `balena-supervisor` or `core`
@@ -85,7 +85,7 @@ volumes:
     labels:
       # the cache version, can be bumped to force re-creation of the volume
       # on a new release
-      io.balena.private.version: "0"
+      io.balena.private.version: '1'
   runtime:
     driver: local
     driver_opts:

--- a/src/api-binder/poll.ts
+++ b/src/api-binder/poll.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events';
-import url from 'url';
 import { setTimeout } from 'timers/promises';
 import type StrictEventEmitter from 'strict-event-emitter-types';
 import { Agent } from 'https';
@@ -11,6 +10,7 @@ import * as config from '../config';
 import { takeGlobalLockRWDisposer } from '../lib/process-lock';
 import * as constants from '../lib/constants';
 import log from '../lib/supervisor-console';
+import { resolveURL } from '../lib/api-helper';
 
 export class ApiResponseError extends Error {}
 
@@ -132,7 +132,7 @@ export const update = async (
 		);
 	}
 
-	const endpoint = url.resolve(
+	const endpoint = resolveURL(
 		apiEndpointOverride ?? apiEndpoint,
 		`/device/v3/${uuid}/state`,
 	);
@@ -150,6 +150,7 @@ export const update = async (
 			Authorization: `Bearer ${deviceApiKey}`,
 			'If-None-Match': cache?.etag,
 		},
+		enableUnixSockets: true,
 		timeout: {
 			// TODO: We use the same default timeout for all of these in order to have a timeout generally
 			// but it would probably make sense to tune them individually

--- a/src/api-binder/report.ts
+++ b/src/api-binder/report.ts
@@ -1,4 +1,3 @@
-import url from 'url';
 import type { CoreOptions } from 'request';
 import { performance } from 'perf_hooks';
 import { setTimeout } from 'timers/promises';
@@ -17,6 +16,7 @@ import { shallowDiff, prune, empty } from '../lib/json';
 import { pathOnRoot } from '../lib/host-utils';
 import { touch, writeAndSyncFile } from '../lib/fs-utils';
 import pTimeout from 'p-timeout';
+import { resolveURL } from '../lib/api-helper';
 
 let lastReport: DeviceState = {};
 let lastReportTime = -Infinity;
@@ -53,9 +53,9 @@ async function report({ body, opts }: StateReport) {
 		);
 	}
 
-	const endpoint = url.resolve(
+	const endpoint = resolveURL(
 		apiEndpointOverride ?? apiEndpoint,
-		`/device/v3/state`,
+		'/device/v3/state',
 	);
 	const request = await getRequestInstance();
 

--- a/src/lib/api-helper.ts
+++ b/src/lib/api-helper.ts
@@ -17,6 +17,7 @@ import log from './supervisor-console';
 import memoizee from 'memoizee';
 import url from 'url';
 import type { BalenaModel } from 'balena-sdk';
+import { pathOnRoot } from './host-utils';
 
 export type KeyExchangeOpts = config.ConfigType<'provisioningOptions'>;
 
@@ -24,14 +25,15 @@ export const getBalenaApi = memoizee(
 	async () => {
 		await config.initialized();
 
-		const { apiEndpoint, apiEndpointOverride, currentApiKey } =
-			await config.getMany([
-				'apiEndpoint',
-				'apiEndpointOverride',
-				'currentApiKey',
-			]);
+		const { apiEndpoint, currentApiKey } = await config.getMany([
+			'apiEndpoint',
+			'currentApiKey',
+		]);
 
-		const baseUrl = url.resolve(apiEndpointOverride ?? apiEndpoint, '/v7/');
+		// we don't use the apiEndpointOverride here to avoid interfering with
+		// provisioning. Poll/report doesn't use the pine client, so there is no added
+		// benefit of overriding this URL too
+		const baseUrl = url.resolve(apiEndpoint, '/v7/');
 		const passthrough = structuredClone(await request.getRequestOptions());
 		passthrough.headers = passthrough.headers ?? {};
 		passthrough.headers.Authorization = `Bearer ${currentApiKey}`;
@@ -265,3 +267,19 @@ export const provision = async (
 		eventTracker.track('Device bootstrap success');
 	}
 };
+
+/**
+ * Resolve a URL with respect to an endpoint
+ *
+ * If using unix domain sockets, formats the URL/path with a path relative to the root path assuming http
+ */
+export function resolveURL(endpoint: string, path: string): string {
+	// if the URL starts with `/`, assume a unix domain socket
+	if (endpoint.startsWith('/')) {
+		const rootPath = pathOnRoot(endpoint);
+		// see https://github.com/sindresorhus/got/blob/v14.6.6/documentation/2-options.md#enableunixsockets
+		// see https://www.npmjs.com/package/request#unix-domain-sockets
+		return `http://unix:${rootPath}:${path}`;
+	}
+	return url.resolve(endpoint, path);
+}


### PR DESCRIPTION
This allows the `apiEndpointOverride` to point to a file (socket), rather than provide a URL. When running alongside helios, this should allow the supervisor to communicate directly to that service, rather than going through the `service-relay`. 

This also limits API override communication to the poll/report, and ignores it for other communication with the API. This makes sure that provisioning works as before


Depends-on: balena-io/helios#153