### PR TITLE
Migrate Flowzone caller off pull_request_target

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -4,20 +4,15 @@ on:
   pull_request:
     types: [opened, synchronize, closed]
     branches: [main, master]
-  # allow external contributions to use secrets within trusted code
-  pull_request_target:
-    types: [opened, synchronize, closed]
+  # fork contributions are rebuilt and published from the push to the
+  # default branch after merge, so untrusted code never sees secrets
+  push:
     branches: [main, master]
 
 jobs:
   flowzone:
     name: Flowzone
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
-    # prevent duplicate workflows and only allow one `pull_request` or `pull_request_target` for
-    # internal or external contributions respectively
-    if: |
-      (github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request') ||
-      (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     secrets: inherit
     with:
       restrict_custom_actions: false


### PR DESCRIPTION
Necessary due to error message on GHA runs from external contributors:
```
Error: Flowzone no longer runs on 'pull_request_target' events. External (fork)   contributions are being migrated to a 'pull_request' + 'push' flow that never exposes   secrets to untrusted code. See the Flowzone trust-boundary documentation.
Error: Process completed with exit code 1.
```

See: https://github.com/balena-os/balena-supervisor/actions/runs/32515208576/job/96931315286?pr=2543#step:2:1