### PR TITLE
Use the 10.114.105.x subnet for supervisor services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,3 +92,16 @@ volumes:
       type: none
       o: bind
       device: /tmp
+
+networks:
+  # Use the 10.114.X range for the default network to minimize the probability
+  # of clashing with the local network environment
+  # TODO: this network should eventually replace the `supervisor0` network
+  default:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.114.105.0/25
+          gateway: 10.114.105.1
+


### PR DESCRIPTION
Supervisor services were using the docker default 172.17.x range for their network configuration. This could cause an issue if that range is used for other devices on the same network. This moves to the `10.114.x` subnet, mirroring what we do for the `supervisor0` network, which should reduce the probability of clashing.

Change-type: patch