### PR TITLE
Revert "Migrate Flowzone caller off pull_request_target"

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -4,15 +4,20 @@ on:
   pull_request:
     types: [opened, synchronize, closed]
     branches: [main, master]
-  # fork contributions are rebuilt and published from the push to the
-  # default branch after merge, so untrusted code never sees secrets
-  push:
+  # allow external contributions to use secrets within trusted code
+  pull_request_target:
+    types: [opened, synchronize, closed]
     branches: [main, master]
 
 jobs:
   flowzone:
     name: Flowzone
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
+    # prevent duplicate workflows and only allow one `pull_request` or `pull_request_target` for
+    # internal or external contributions respectively
+    if: |
+      (github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request') ||
+      (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     secrets: inherit
     with:
       restrict_custom_actions: false


### PR DESCRIPTION
This reverts commit 7f92059c72ab48fba547c718241b0a9a613a13ca. Some additional configuration is needed, this change seems to be building multiple balena releases for the supervisor on balenaCloud.

Change-type: patch