### PR TITLE
Make the default network config-only for none networking too

### DIFF
--- a/src/compose/app.ts
+++ b/src/compose/app.ts
@@ -87,8 +87,10 @@ class AppImpl implements App {
 			this.networks.find((n) => n.name === 'default') == null &&
 			isTargetState
 		) {
-			const allHostNetworking = this.services.every(
-				(svc) => svc.config.networkMode === 'host',
+			const allHostOrNoneNetworking = this.services.every(
+				(svc) =>
+					svc.config.networkMode === 'host' ||
+					svc.config.networkMode === 'none',
 			);
 			// We always want a default network
 			this.networks.push(
@@ -101,7 +103,7 @@ class AppImpl implements App {
 					// aren't using it, to minimize chances of host-Docker address conflicts.
 					// If config_only is specified, the network is created and available in Docker
 					// by name and config only, and no actual networking setup occurs.
-					{ config_only: allHostNetworking },
+					{ config_only: allHostOrNoneNetworking },
 				),
 			);
 		}

--- a/test/unit/compose/app.spec.ts
+++ b/test/unit/compose/app.spec.ts
@@ -1056,7 +1056,7 @@ describe('compose/app', () => {
 				.that.deep.includes({ configOnly: true });
 		});
 
-		it('should not create a config-only network if network_mode: host is not specified for any service', async () => {
+		it('should not create a config-only network if network_mode: host or none is not specified for any service', async () => {
 			const svcOne = await createService({
 				appId: 1,
 				serviceName: 'one',
@@ -1083,6 +1083,36 @@ describe('compose/app', () => {
 				.to.have.property('target')
 				.that.has.property('config')
 				.that.deep.includes({ configOnly: false });
+		});
+
+		it('should create a config-only network if network_mode is none for all services', async () => {
+			const svcOne = await createService({
+				appId: 1,
+				serviceName: 'one',
+				composition: { network_mode: 'none' },
+			});
+			const svcTwo = await createService({
+				appId: 1,
+				serviceName: 'two',
+				composition: { network_mode: 'none' },
+			});
+			const current = createApp({
+				services: [svcOne, svcTwo],
+				networks: [],
+			});
+			const target = createApp({
+				services: [svcOne, svcTwo],
+				networks: [],
+				isTarget: true,
+			});
+
+			const steps = current.nextStepsForAppUpdate(defaultContext, target);
+
+			const [createNetworkStep] = expectSteps('createNetwork', steps);
+			expect(createNetworkStep)
+				.to.have.property('target')
+				.that.has.property('config')
+				.that.deep.includes({ configOnly: true });
 		});
 
 		it('should create a config-only network if there are no services in the app', () => {


### PR DESCRIPTION
The default network was only created as config-only when every service used host networking, so a service with network_mode: none still got a real bridge with an auto-assigned subnet that can clash with the device's LAN.

Change-type: patch