### PR TITLE
Migrate Flowzone caller off pull_request_target

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -4,20 +4,15 @@ on:
   pull_request:
     types: [opened, synchronize, closed]
     branches: [main, master]
-  # allow external contributions to use secrets within trusted code
-  pull_request_target:
-    types: [opened, synchronize, closed]
+  # fork contributions are rebuilt and published from the push to the
+  # default branch after merge, so untrusted code never sees secrets
+  push:
     branches: [main, master]
 
 jobs:
   flowzone:
     name: Flowzone
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
-    # prevent duplicate workflows and only allow one `pull_request` or `pull_request_target` for
-    # internal or external contributions respectively
-    if: |
-      (github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request') ||
-      (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     secrets: inherit
     with:
       restrict_custom_actions: false


### PR DESCRIPTION
Reapplies 7f92059c, reverted in 96a908df. The duplicate release issue is fixed in flowzone 23.1.6.

Change-type: patch